### PR TITLE
Update link to new canonical fork.

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -81,7 +81,7 @@ coerce. Following on the success of ``s3fs`` and ``gcsfs``, and their use within
 have an interface as close to those as possible. See a
 `discussion`_ on the topic.
 
-.. _discussion: https://github.com/martindurant/filesystem_spec/issues/5
+.. _discussion: https://github.com/intake/filesystem_spec/issues/5
 
 Structure of the package
 ------------------------


### PR DESCRIPTION
GitHub forwards links when repos are moved, but in this case that is broken by
the existence of a new ``martindurant`` fork.