### PR TITLE
Added adl protocol to registry.py, and added lowercasing to isdir() a…

### DIFF
--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -30,6 +30,8 @@ known_implementations = {
                 'err': 'webHDFS access requires "requests" to be installed'},
     's3': {'class': 's3fs.S3FileSystem',
            'err': 'Install s3fs to access S3'},
+    'adl': {'class': 'adlfs.AzureDatalakeFileSystem',
+            'err': 'Install adlfs to access files stored on Azure Datalake Gen1 from https://github.com/hayesgb/adlfs'},
     'cached': {'class': 'fsspec.implementations.cached.CachingFileSystem'},
     'dask': {'class': 'fsspec.implementations.dask.DaskWorkerFileSystem',
              'err': 'Install dask distributed to access worker file system'}

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -523,14 +523,14 @@ class AbstractFileSystem(up):
     def isdir(self, path):
         """Is this entry directory-like?"""
         try:
-            return self.info(path)['type'] == 'directory'
+            return self.info(path)['type'].lower() == 'directory'
         except FileNotFoundError:
             return False
 
     def isfile(self, path):
         """Is this entry file-like?"""
         try:
-            return self.info(path)['type'] == 'file'
+            return self.info(path)['type'].lower() == 'file'
         except:
             return False
 


### PR DESCRIPTION
Wanted to get started with the Azure Datalake Gen1 implementation.  I've added adl to registry.py, with error instructions to install the adlfs library currently located in my repository.  I will create a pip installable over the next few days for that, and then begin adding tests.  The only changes implemented here are to the registry.py file, and lowercasing of the returns from the isfile and isdir method calls in core.py.  This is needed because the response of an info() call from Azure is all-caps, which returns an error with core.py as written.