### PR TITLE
Attribute 'info' is now retrieved from pyarrow

### DIFF
--- a/fsspec/implementations/hdfs.py
+++ b/fsspec/implementations/hdfs.py
@@ -107,6 +107,7 @@ class PyArrowHDFS(AbstractFileSystem):
             'get_space_used', 'df', 'chmod', 'chown', 'disk_usage',
             'download', 'upload', '_get_kwargs_from_urls',
             'read_parquet', 'rm', 'stat', 'upload',
+            'info',
         ]:
             return getattr(pahdfs, item)
         else:


### PR DESCRIPTION
The attribute 'info' was added to the list of attributes to be retrieved from the underlying HadoopFileSystem object in PyArrowHDFS.