### PR TITLE
Strip protocol in paths returned by 'ls'

### DIFF
--- a/fsspec/implementations/hdfs.py
+++ b/fsspec/implementations/hdfs.py
@@ -67,6 +67,9 @@ class PyArrowHDFS(AbstractFileSystem):
         if detail:
             for p in out:
                 p['type'] = p['kind']
+                p["name"] = self._strip_protocol(p["name"])
+        else:
+            out = [self._strip_protocol(p) for p in out]
         return out
 
     @staticmethod
@@ -107,7 +110,6 @@ class PyArrowHDFS(AbstractFileSystem):
             'get_space_used', 'df', 'chmod', 'chown', 'disk_usage',
             'download', 'upload', '_get_kwargs_from_urls',
             'read_parquet', 'rm', 'stat', 'upload',
-            'info',
         ]:
             return getattr(pahdfs, item)
         else:


### PR DESCRIPTION
The previous changes had as an effect to by pass the 'ls' method which is used in the base class AbstractFileSystem.

There seem to be a difference between what is returned by ls in the test docker in dask and what is returned using an actual HDFS server.

In my case, when doing:

```python
hdfs=pyarrow.hdfs.connect(host="myserver", port=xxxx)
hdfs.ls("path/to/file", detail=True)
```
... the protocol information is prepended to the path while it is not the case in the test docker.

This explains while nothing was detected. My corrections consists in calling `_strip_protocol` on the output as expected by the `info` method on the `AbstractFileSystem`.

this PR is related to the dask issue: https://github.com/dask/dask/issues/5285
and reverts and corrects the previous modification in the PR: https://github.com/intake/filesystem_spec/pull/107