### PR TITLE
Add "split_before" option to `fsspec.utils.read_block`

### DIFF
--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -145,6 +145,8 @@ def seek_delimiter(file, delimiter, blocksize):
 
     Seeks file to next chunk delimiter, where chunks are defined on file start,
     a delimiting sequence, and file end. Use file.tell() to see location afterwards.
+    Note that file start is a valid split, so must be at offset > 0 to seek for
+    delimiter.
 
     Parameters
     ----------
@@ -162,6 +164,7 @@ def seek_delimiter(file, delimiter, blocksize):
     """
 
     if file.tell() == 0:
+        # beginning-of-file, return without seek
         return False
 
     # Interface is for binary IO, with delimiter as bytes, but initialize last
@@ -170,7 +173,8 @@ def seek_delimiter(file, delimiter, blocksize):
     while True:
         current = file.read(blocksize)
         if not current:
-            return
+            # end-of-file without delimiter
+            return False
         full = last + current if last else current
         try:
             if delimiter in full:

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -141,24 +141,30 @@ def build_name_function(max_int):
 
 
 def seek_delimiter(file, delimiter, blocksize):
-    """ Seek current file to next byte after a delimiter bytestring
+    r"""Seek current file to byte after file start, delimiter seq or file end.
 
-    This seeks the file to the next byte following the delimiter.  It does
-    not return anything.  Use ``file.tell()`` to see location afterwards.
+    Seeks file to next chunk delimiter, where chunks are defined on file start,
+    a delimiting sequence, and file end. Use file.tell() to see location afterwards.
 
     Parameters
     ----------
     file: a file
-    delimiter: bytes
-        a delimiter like ``b'\n'`` or message sentinel
+    delimiter: bytes or str
+        a delimiter like ``b'\n'`` or message sentinel, matching file .read() type
     blocksize: int
         Number of bytes to read from the file at once.
+
+
+    Returns
+    -------
+    Returns True if a delimiter was found, False if at file start or end.
+
     """
 
     if file.tell() == 0:
-        return
+        return False
 
-    last = b''
+    last = type(delimiter)()
     while True:
         current = file.read(blocksize)
         if not current:
@@ -168,34 +174,37 @@ def seek_delimiter(file, delimiter, blocksize):
             if delimiter in full:
                 i = full.index(delimiter)
                 file.seek(file.tell() - (len(full) - i) + len(delimiter))
-                return
+                return True
             elif len(current) < blocksize:
                 # end-of-file without delimiter
-                return
-        except ValueError:
+                return False
+        except (OSError, ValueError):
             pass
         last = full[-len(delimiter):]
 
 
-def read_block(f, offset, length, delimiter=None):
+def read_block(f, offset, length, delimiter=None, split_before=False):
     """ Read a block of bytes from a file
 
     Parameters
     ----------
-    fn: string
-        Path to filename
+    f: File
+        Open file
     offset: int
         Byte offset to start read
     length: int
-        Number of bytes to read
+        Number of bytes to read, read through end of file if None
     delimiter: bytes (optional)
         Ensure reading starts and stops at delimiter bytestring
+    split_before: bool (optional)
+        Start/stop read *before* delimiter bytestring.
+
 
     If using the ``delimiter=`` keyword argument we ensure that the read
     starts and stops at delimiter boundaries that follow the locations
     ``offset`` and ``offset + length``.  If ``offset`` is zero then we
-    start at zero.  The bytestring returned WILL include the
-    terminating delimiter string.
+    start at zero, regardless of delimiter.  The bytestring returned WILL
+    include the terminating delimiter string.
 
     Examples
     --------
@@ -213,15 +222,21 @@ def read_block(f, offset, length, delimiter=None):
     """
     if delimiter:
         f.seek(offset)
-        seek_delimiter(f, delimiter, 2**16)
+        found_start_delim = seek_delimiter(f, delimiter, 2 ** 16)
         if length is None:
             return f.read()
         start = f.tell()
         length -= start - offset
 
         f.seek(start + length)
-        seek_delimiter(f, delimiter, 2**16)
+        found_end_delim = seek_delimiter(f, delimiter, 2 ** 16)
         end = f.tell()
+
+        if found_start_delim and split_before:
+            start -= len(delimiter)
+
+        if found_end_delim and split_before:
+            end -= len(delimiter)
 
         offset = start
         length = end - start


### PR DESCRIPTION
Add "split_before" option to read_block, allowing read_block to
partition blocks both before and after delimiters. Useful is splitting
blocks on arbitrary byte headers, such as ">" headers used in FASTA
formatted sequences and opening tags in large XML documents.

This will be followed by a pull in dask extending support for split_before logic to read_text.