### PR TITLE
Add gzip test to webhdfs

### DIFF
--- a/fsspec/implementations/tests/test_webhdfs.py
+++ b/fsspec/implementations/tests/test_webhdfs.py
@@ -74,6 +74,20 @@ def test_workflow(hdfs_cluster):
     assert not w.exists(fn)
 
 
+def test_with_gzip(hdfs_cluster):
+    from gzip import GzipFile
+    w = WebHDFS(hdfs_cluster, user='testuser',
+                data_proxy={'worker.example.com': 'localhost'})
+    fn = '/user/testuser/gzfile'
+    with w.open(fn, 'wb') as f:
+        gf = GzipFile(fileobj=f, mode='w')
+        gf.write(b'hello')
+        gf.close()
+    with w.open(fn, 'rb') as f:
+        gf = GzipFile(fileobj=f, mode='r')
+        assert gf.read() == b'hello'
+
+
 def test_workflow_transaction(hdfs_cluster):
     w = WebHDFS(hdfs_cluster, user='testuser',
                 data_proxy={'worker.example.com': 'localhost'})


### PR DESCRIPTION
Resolves https://github.com/dask/dask/issues/5257

( @AlbertDeFusco , gzip also seeks past the end of the file, so this shows that pandas should work fine too)