### PR TITLE
Add `infer_compression` support for zstd/lz4 compression.

### DIFF
--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -35,19 +35,22 @@ def register_compression(name, callback, extensions, force=False):
         ValueError: If name or extensions already registered, and not force.
 
     """
-    if name in compr and not force:
-        raise ValueError("Duplicate compression registration: %s" % name)
-
-    compr[name] = callback
-
     if isinstance(extensions, str):
         extensions = [extensions]
+
+    # Validate registration
+    if name in compr and not force:
+        raise ValueError("Duplicate compression registration: %s" % name)
 
     for ext in extensions:
         if ext in fsspec.utils.compressions and not force:
             raise ValueError(
                 "Duplicate compression file extension: %s (%s)" % (ext, name)
             )
+
+    compr[name] = callback
+
+    for ext in extensions:
         fsspec.utils.compressions[ext] = name
 
 

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -3,9 +3,9 @@ from __future__ import print_function, division, absolute_import
 import io
 import os
 import logging
-from .compression import compr
-from .utils import (infer_compression, build_name_function,
-                    update_storage_options, stringify_path)
+from .compression import compr, infer_compression
+from .utils import (build_name_function, update_storage_options,
+                    stringify_path)
 from .registry import get_filesystem_class
 logger = logging.getLogger('fsspec')
 

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -3,9 +3,9 @@ from __future__ import print_function, division, absolute_import
 import io
 import os
 import logging
-from .compression import compr, infer_compression
-from .utils import (build_name_function, update_storage_options,
-                    stringify_path)
+from .compression import compr
+from .utils import (infer_compression, build_name_function,
+                    update_storage_options, stringify_path)
 from .registry import get_filesystem_class
 logger = logging.getLogger('fsspec')
 

--- a/fsspec/tests/test_compression.py
+++ b/fsspec/tests/test_compression.py
@@ -1,3 +1,8 @@
+import pathlib
+
+import pytest
+
+import fsspec.core
 from fsspec.compression import compr, register_compression
 from fsspec.utils import compressions, infer_compression
 
@@ -21,3 +26,98 @@ def test_infer_custom_compression():
     finally:
         del compr["test_custom"]
         del compressions["tst"]
+
+
+def test_lz4_compression(tmp_path):
+    # type: (pathlib.Path) -> None
+    """Infer lz4 compression for .lz4 files if lz4 is available."""
+
+    lz4 = pytest.importorskip("lz4")
+
+    tmp_path.mkdir(exist_ok=True)
+
+    tdat = "foobar" * 100
+
+    with fsspec.core.open(
+        str(tmp_path / "out.lz4"), mode="wt", compression="infer"
+    ) as outfile:
+        outfile.write(tdat)
+
+    compressed = (tmp_path / "out.lz4").open("rb").read()
+    assert lz4.frame.decompress(compressed).decode() == tdat
+
+    with fsspec.core.open(
+        str(tmp_path / "out.lz4"), mode="rt", compression="infer"
+    ) as infile:
+        assert infile.read() == tdat
+
+    with fsspec.core.open(
+        str(tmp_path / "out.lz4"), mode="rt", compression="lz4"
+    ) as infile:
+        assert infile.read() == tdat
+
+
+def test_zstd_compression(tmp_path):
+    # type: (pathlib.Path) -> None
+    """Infer zstd compression for .zst files if zstandard is available."""
+
+    zstd = pytest.importorskip("zstandard")
+
+    tmp_path.mkdir(exist_ok=True)
+
+    tdat = "foobar" * 100
+
+    with fsspec.core.open(
+        str(tmp_path / "out.zst"), mode="wt", compression="infer"
+    ) as outfile:
+        outfile.write(tdat)
+
+    compressed = (tmp_path / "out.zst").open("rb").read()
+    assert zstd.ZstdDecompressor().decompress(compressed, len(tdat)).decode() == tdat
+
+    with fsspec.core.open(
+        str(tmp_path / "out.zst"), mode="rt", compression="infer"
+    ) as infile:
+        assert infile.read() == tdat
+
+    with fsspec.core.open(
+        str(tmp_path / "out.zst"), mode="rt", compression="zstd"
+    ) as infile:
+        assert infile.read() == tdat
+
+
+def test_snappy_compression(tmp_path):
+    """No registered compression for snappy, but can be specified."""
+    # type: (pathlib.Path) -> None
+
+    snappy = pytest.importorskip("snappy")
+
+    tmp_path.mkdir(exist_ok=True)
+
+    tdat = "foobar" * 100
+
+    # Snappy isn't inferred.
+    with fsspec.core.open(
+        str(tmp_path / "out.snappy"), mode="wt", compression="infer"
+    ) as outfile:
+        outfile.write(tdat)
+    assert (tmp_path / "out.snappy").open("rb").read().decode() == tdat
+
+    # but can be specified.
+    with fsspec.core.open(
+        str(tmp_path / "out.snappy"), mode="wt", compression="snappy"
+    ) as outfile:
+        outfile.write(tdat)
+
+    compressed = (tmp_path / "out.snappy").open("rb").read()
+    assert snappy.StreamDecompressor().decompress(compressed).decode() == tdat
+
+    with fsspec.core.open(
+        str(tmp_path / "out.snappy"), mode="rb", compression="infer"
+    ) as infile:
+        assert infile.read() == compressed
+
+    with fsspec.core.open(
+        str(tmp_path / "out.snappy"), mode="rt", compression="snappy"
+    ) as infile:
+        assert infile.read() == tdat

--- a/fsspec/tests/test_compression.py
+++ b/fsspec/tests/test_compression.py
@@ -1,25 +1,23 @@
-from fsspec.compression import infer_compression, compr, compr_extensions
+from fsspec.compression import compr, register_compression
+from fsspec.utils import compressions, infer_compression
 
 
 def test_infer_custom_compression():
     """Inferred compression gets values from fsspec.compression.compr."""
     assert infer_compression("fn.zip") == "zip"
     assert infer_compression("fn.gz") == "gzip"
-    assert infer_compression("fn.gzip") == "gzip"
     assert infer_compression("fn.unknown") is None
     assert infer_compression("fn.test_custom") is None
     assert infer_compression("fn.tst") is None
 
-    compr["test_custom"] = lambda f, **kwargs: f
-    compr_extensions["tst"] = "test_custom"
+    register_compression("test_custom", lambda f, **kwargs: f, "tst")
 
     try:
         assert infer_compression("fn.zip") == "zip"
         assert infer_compression("fn.gz") == "gzip"
-        assert infer_compression("fn.gzip") == "gzip"
         assert infer_compression("fn.unknown") is None
-        assert infer_compression("fn.test_custom") == "test_custom"
+        assert infer_compression("fn.test_custom") is None
         assert infer_compression("fn.tst") == "test_custom"
     finally:
         del compr["test_custom"]
-        del compr_extensions["tst"]
+        del compressions["tst"]

--- a/fsspec/tests/test_compression.py
+++ b/fsspec/tests/test_compression.py
@@ -23,8 +23,28 @@ def test_infer_custom_compression():
         assert infer_compression("fn.unknown") is None
         assert infer_compression("fn.test_custom") is None
         assert infer_compression("fn.tst") == "test_custom"
+
+        # Duplicate registration in name or extension raises a value error.
+        with pytest.raises(ValueError):
+            register_compression("test_custom", lambda f, **kwargs: f, "tst")
+
+        with pytest.raises(ValueError):
+            register_compression("test_conflicting", lambda f, **kwargs: f, "tst")
+        assert "test_conflicting" not in compr
+
+        # ...but can be forced.
+        register_compression(
+            "test_conflicting", lambda f, **kwargs: f, "tst", force=True
+        )
+        assert infer_compression("fn.zip") == "zip"
+        assert infer_compression("fn.gz") == "gzip"
+        assert infer_compression("fn.unknown") is None
+        assert infer_compression("fn.test_custom") is None
+        assert infer_compression("fn.tst") == "test_conflicting"
+
     finally:
         del compr["test_custom"]
+        del compr["test_conflicting"]
         del compressions["tst"]
 
 

--- a/fsspec/tests/test_compression.py
+++ b/fsspec/tests/test_compression.py
@@ -1,0 +1,25 @@
+from fsspec.compression import infer_compression, compr, compr_extensions
+
+
+def test_infer_custom_compression():
+    """Inferred compression gets values from fsspec.compression.compr."""
+    assert infer_compression("fn.zip") == "zip"
+    assert infer_compression("fn.gz") == "gzip"
+    assert infer_compression("fn.gzip") == "gzip"
+    assert infer_compression("fn.unknown") is None
+    assert infer_compression("fn.test_custom") is None
+    assert infer_compression("fn.tst") is None
+
+    compr["test_custom"] = lambda f, **kwargs: f
+    compr_extensions["tst"] = "test_custom"
+
+    try:
+        assert infer_compression("fn.zip") == "zip"
+        assert infer_compression("fn.gz") == "gzip"
+        assert infer_compression("fn.gzip") == "gzip"
+        assert infer_compression("fn.unknown") is None
+        assert infer_compression("fn.test_custom") == "test_custom"
+        assert infer_compression("fn.tst") == "test_custom"
+    finally:
+        del compr["test_custom"]
+        del compr_extensions["tst"]

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -1,30 +1,6 @@
 import io
 import pytest
-from fsspec.utils import infer_storage_options, infer_compression, seek_delimiter, read_block
-from fsspec.compression import compr
-
-
-def test_infer_compression():
-    assert infer_compression('fn.zip') == 'zip'
-    assert infer_compression('fn.gz') == 'gzip'
-    assert infer_compression('fn.unknown') is None
-
-def test_infer_custom_compression():
-    """Inferred compression gets values from fsspec.compression.compr."""
-    assert infer_compression('fn.zip') == 'zip'
-    assert infer_compression('fn.gz') == 'gzip'
-    assert infer_compression('fn.unknown') is None
-    assert infer_compression("fn.test_custom") is None
-
-    compr["test_custom"] = lambda f, **kwargs: f
-
-    try:
-        assert infer_compression('fn.zip') == 'zip'
-        assert infer_compression('fn.gz') == 'gzip'
-        assert infer_compression('fn.unknown') is None
-        assert infer_compression("fn.test_custom") is "test_custom"
-    finally:
-        del compr["test_custom"]
+from fsspec.utils import infer_storage_options, seek_delimiter, read_block
 
 
 def test_read_block():

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -1,12 +1,30 @@
 import io
 import pytest
 from fsspec.utils import infer_storage_options, infer_compression, seek_delimiter, read_block
+from fsspec.compression import compr
 
 
 def test_infer_compression():
     assert infer_compression('fn.zip') == 'zip'
     assert infer_compression('fn.gz') == 'gzip'
     assert infer_compression('fn.unknown') is None
+
+def test_infer_custom_compression():
+    """Inferred compression gets values from fsspec.compression.compr."""
+    assert infer_compression('fn.zip') == 'zip'
+    assert infer_compression('fn.gz') == 'gzip'
+    assert infer_compression('fn.unknown') is None
+    assert infer_compression("fn.test_custom") is None
+
+    compr["test_custom"] = lambda f, **kwargs: f
+
+    try:
+        assert infer_compression('fn.zip') == 'zip'
+        assert infer_compression('fn.gz') == 'gzip'
+        assert infer_compression('fn.unknown') is None
+        assert infer_compression("fn.test_custom") is "test_custom"
+    finally:
+        del compr["test_custom"]
 
 
 def test_read_block():

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -102,6 +102,21 @@ def update_storage_options(options, inherited=None):
     options.update(inherited)
 
 
+# Compression extensions registered via fsspec.compression.register_compression
+compressions = {}
+
+
+def infer_compression(filename):
+    """Infer compression, if available, from filename.
+
+    Infer a named compression type, if registered and available, from filename
+    extension. This includes builtin (gz, bz2, zip) compressions, as well as
+    optional compressions. See fsspec.compression.register_compression.
+    """
+    extension = os.path.splitext(filename)[-1].strip('.')
+    if extension in compressions:
+        return compressions[extension]
+
 
 def build_name_function(max_int):
     """ Returns a function that receives a single integer

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -102,14 +102,6 @@ def update_storage_options(options, inherited=None):
     options.update(inherited)
 
 
-compressions = {'gz': 'gzip', 'bz2': 'bz2', 'xz': 'xz', 'zip': 'zip'}
-
-
-def infer_compression(filename):
-    extension = os.path.splitext(filename)[-1].strip('.')
-    if extension in compressions:
-        return compressions[extension]
-
 
 def build_name_function(max_int):
     """ Returns a function that receives a single integer


### PR DESCRIPTION
Proof of concept fix for #129. Not suitable in current from, as "infer_compression" is moved to break the `utils`/`compression` import cycle. 