### PR TITLE
Add check for type == file before checking name == path

### DIFF
--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -79,12 +79,10 @@ class FTPFileSystem(AbstractFileSystem):
         out = []
         if path not in self.dircache:
             try:
-                out = list(self.ftp.mlsd(path))
+                out = [(fn, details) for (fn, details) in self.ftp.mlsd(path) if fn not in ['.' '..']]
                 for fn, details in out:
                     if path == '/':
                         path = ''  # just for forming the names, below
-                    if fn in ['.', '..']:
-                        continue
                     details['name'] = '/'.join([path, fn.lstrip('/')])
                     if details['type'] == 'file':
                         details['size'] = int(details['size'])

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -79,7 +79,9 @@ class FTPFileSystem(AbstractFileSystem):
         out = []
         if path not in self.dircache:
             try:
-                out = [(fn, details) for (fn, details) in self.ftp.mlsd(path) if fn not in ['.' '..']]
+                out = [(fn, details) for (fn, details) in self.ftp.mlsd(path)
+                       if fn not in ['.', '..']
+                       and details['type'] not in ['pdir', 'cdir']]
                 for fn, details in out:
                     if path == '/':
                         path = ''  # just for forming the names, below


### PR DESCRIPTION
- sometimes if entry does not have name eg "." or ".." causes KeyError.

- all entries of type file have a name

re #135 