### PR TITLE
Fix XZ compression name

### DIFF
--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -2,6 +2,7 @@
 from bz2 import BZ2File
 from gzip import GzipFile
 from zipfile import ZipFile
+from lzma import LZMAFile
 
 import fsspec.utils
 from fsspec.spec import AbstractBufferedFile
@@ -70,13 +71,7 @@ def unzip(infile, mode="rb", filename=None, **kwargs):
 register_compression("zip", unzip, "zip")
 register_compression("bz2", BZ2File, "bz2")
 register_compression("gzip", lambda f, **kwargs: GzipFile(fileobj=f, **kwargs), "gz")
-
-try:
-    import lzma
-
-    register_compression("xz", lzma.LZMAFile, "xz")
-except ImportError:
-    pass
+register_compression("xz", LZMAFile, "xz")
 
 try:
     import lzmaffi

--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -74,13 +74,15 @@ register_compression("gzip", lambda f, **kwargs: GzipFile(fileobj=f, **kwargs), 
 try:
     import lzma
 
-    register_compression("xz", lzma.LZMAFile, "xz")
+    register_compression("lzma", lzma.LZMAFile, "xz")
+    register_compression("xz", lzma.LZMAFile, "xz", force=True)
 except ImportError:
     pass
 
 try:
     import lzmaffi
 
+    register_compression("lzma", lzmaffi.LZMAFile, "xz", force=True)
     register_compression("xz", lzmaffi.LZMAFile, "xz", force=True)
 except ImportError:
     pass

--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -2,7 +2,6 @@
 from bz2 import BZ2File
 from gzip import GzipFile
 from zipfile import ZipFile
-from lzma import LZMAFile
 
 import fsspec.utils
 from fsspec.spec import AbstractBufferedFile
@@ -71,7 +70,13 @@ def unzip(infile, mode="rb", filename=None, **kwargs):
 register_compression("zip", unzip, "zip")
 register_compression("bz2", BZ2File, "bz2")
 register_compression("gzip", lambda f, **kwargs: GzipFile(fileobj=f, **kwargs), "gz")
-register_compression("xz", LZMAFile, "xz")
+
+try:
+    import lzma
+
+    register_compression("xz", lzma.LZMAFile, "xz")
+except ImportError:
+    pass
 
 try:
     import lzmaffi

--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -74,14 +74,14 @@ register_compression("gzip", lambda f, **kwargs: GzipFile(fileobj=f, **kwargs), 
 try:
     import lzma
 
-    register_compression("lzma", lzma.LZMAFile, "xz")
+    register_compression("xz", lzma.LZMAFile, "xz")
 except ImportError:
     pass
 
 try:
     import lzmaffi
 
-    register_compression("lzma", lzmaffi.LZMAFile, "xz", force=True)
+    register_compression("xz", lzmaffi.LZMAFile, "xz", force=True)
 except ImportError:
     pass
 

--- a/fsspec/tests/test_compression.py
+++ b/fsspec/tests/test_compression.py
@@ -11,6 +11,7 @@ def test_infer_custom_compression():
     """Inferred compression gets values from fsspec.compression.compr."""
     assert infer_compression("fn.zip") == "zip"
     assert infer_compression("fn.gz") == "gzip"
+    assert infer_compression("fn.xz") == "xz"
     assert infer_compression("fn.unknown") is None
     assert infer_compression("fn.test_custom") is None
     assert infer_compression("fn.tst") is None

--- a/fsspec/tests/test_compression.py
+++ b/fsspec/tests/test_compression.py
@@ -11,7 +11,6 @@ def test_infer_custom_compression():
     """Inferred compression gets values from fsspec.compression.compr."""
     assert infer_compression("fn.zip") == "zip"
     assert infer_compression("fn.gz") == "gzip"
-    assert infer_compression("fn.xz") == "xz"
     assert infer_compression("fn.unknown") is None
     assert infer_compression("fn.test_custom") is None
     assert infer_compression("fn.tst") is None
@@ -47,6 +46,11 @@ def test_infer_custom_compression():
         del compr["test_custom"]
         del compr["test_conflicting"]
         del compressions["tst"]
+
+
+def test_lzma_compression_name():
+    pytest.importorskip("lzma")
+    assert infer_compression("fn.xz") == "xz"
 
 
 def test_lz4_compression(tmp_path):

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 import pickle
-from fsspec.core import _expand_paths, OpenFile, caches
+from fsspec.core import _expand_paths, OpenFile, caches, get_compression
 from fsspec.implementations.tests.test_memory import m
 
 
@@ -56,3 +56,11 @@ def test_cache_pickleable(Cache_imp):
     assert unpickled.blocksize == blocksize
     assert unpickled.size == size
     assert unpickled._fetch(0, 10) == b'0' * 10
+
+
+def test_xz_lzma_compressions():
+    pytest.importorskip("lzma")
+    # Ensure that both 'xz' and 'lzma' compression names can be parsed
+    assert get_compression('some_file.xz', 'infer') == 'xz'
+    assert get_compression('some_file.xz', 'xz') == 'xz'
+    assert get_compression('some_file.xz', 'lzma') == 'lzma'


### PR DESCRIPTION
It looks like #130 changed the LZMA algorithm compression name from "xz" to "lzma" which is causing backward compatibility issues. For example, using `fsspec==0.4.4`:

```python
In [1]: import fsspec

In [2]: fsspec.__version__
Out[2]: '0.4.4'

In [3]: from fsspec.core import get_compression

In [4]: get_compression('some_file.xz', 'xz')
Out[4]: 'xz'
```

while with the new 0.4.5 `fsspec` release, we have:

```python
In [1]: import fsspec

In [2]: fsspec.__version__
Out[2]: '0.4.5'

In [3]: from fsspec.core import get_compression

In [4]: get_compression('some_file.xz', 'xz')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-31b6a6cda193> in <module>
----> 1 get_compression('some_file.xz', 'xz')

~/miniconda/envs/fsspec-test/lib/python3.7/site-packages/fsspec/core.py in get_compression(urlpath, compression)
    206         compression = infer_compression(urlpath)
    207     if compression is not None and compression not in compr:
--> 208         raise ValueError("Compression type %s not supported" % compression)
    209     return compression
    210

ValueError: Compression type xz not supported
```


This PR reverts the name change back to "xz". 

Came across this on a Dask CI build failure (ref https://travis-ci.org/dask/dask/jobs/585748693#L1057-L1088)