### PR TITLE
Remove universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal: 1
-
 [metadata]
 long_description: file: README.rst
 


### PR DESCRIPTION
Py3 only packages aren't universal.

I already pushed the git tag. I'll manually override this (or do a 0.5.1 if needed).