### PR TITLE
Be more careful starting uploads, particularly for s3

### DIFF
--- a/fsspec/implementations/tests/test_ftp.py
+++ b/fsspec/implementations/tests/test_ftp.py
@@ -109,7 +109,6 @@ def test_write_big(ftp_writable, cache_type):
         assert fs.exists(fn)
         f.write(b"o" * 200)
         f.flush()
-        assert f.buffer.tell() == 0
 
     assert fs.info(fn)["size"] == 1700
     assert fs.cat(fn) == b"o" * 1700

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -978,31 +978,25 @@ class AbstractBufferedFile(io.IOBase):
             raise ValueError("Flush on closed file")
         if force and self.forced:
             raise ValueError("Force flush cannot be called more than once")
+        if force:
+            self.forced = True
 
         if self.mode not in {"wb", "ab"}:
-            assert not hasattr(self, "buffer"), (
-                "flush on read-mode file " "with non-empty buffer"
-            )
+            # no-op to flush on read-mode
             return
-        if self.buffer.tell() == 0 and not force:
-            # no data in the buffer to write
+
+        if not force and self.buffer.tell() < self.blocksize:
+            # Defer write on small block
             return
 
         if self.offset is None:
-            if not force and self.buffer.tell() < self.blocksize:
-                # Defer write on small block
-                return
-            else:
-                # Initialize a multipart upload
-                self.offset = 0
-                self._initiate_upload()
+            # Initialize a multipart upload
+            self.offset = 0
+            self._initiate_upload()
 
         if self._upload_chunk(final=force) is not False:
             self.offset += self.buffer.seek(0, 2)
             self.buffer = io.BytesIO()
-
-        if force:
-            self.forced = True
 
     def _upload_chunk(self, final=False):
         """ Write one part of a multi-block file upload
@@ -1124,8 +1118,6 @@ class AbstractBufferedFile(io.IOBase):
         else:
             if not self.forced:
                 self.flush(force=True)
-            else:
-                assert self.buffer.tell() == 0
 
             if self.fs is not None:
                 self.fs.invalidate_cache(self.path)


### PR DESCRIPTION
Since with s3 we may want single upload or multi-part, and don't
know this until writes are complete