### PR TITLE
Fix bottleneck in AbstractFileSystem.find

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -379,17 +379,17 @@ class AbstractFileSystem(up):
         kwargs are passed to ``ls``.
         """
         # TODO: allow equivalent of -name parameter
-        out = []
+        out = set()
         for path, dirs, files in self.walk(path, maxdepth, **kwargs):
             if withdirs:
                 files += dirs
             for name in files:
                 if name and name not in out:
-                    out.append("/".join([path.rstrip("/"), name]) if path else name)
+                    out.add("/".join([path.rstrip("/"), name]) if path else name)
         if self.isfile(path) and path not in out:
             # walk works on directories, but find should also return [path]
             # when path happens to be a file
-            out.append(path)
+            out.add(path)
         return sorted(out)
 
     def du(self, path, total=True, maxdepth=None, **kwargs):


### PR DESCRIPTION
By changing the list to a set, my test case (writing a zarr array
through s3fs) got 50x higher throughput and went from CPU to IO bound.

This fix is minimal with no semantic changes. It is a question whether the `if name in out` on line 387 and `if path not in out` on line 389 should be dropped, but line 387 in particular is a change in behaviour since it's not necessarily `name` that is added to `out`.