### PR TITLE
Remove [] from around open()...split('\n')

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
     keywords="file",
     packages=["fsspec", "fsspec.implementations"],
     python_requires=">=3.5",
-    install_requires=[open("requirements.txt").read().strip().split("\n")],
+    install_requires=open("requirements.txt").read().strip().split("\n"),
     zip_safe=False,
 )


### PR DESCRIPTION
`split()` already returns a list so you don't need to wrap it in another list.