### PR TITLE
Changed handling of UNC/DFS paths.

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -140,6 +140,9 @@ def make_path_posix(path, sep=os.sep):
         # for windows file URI like "file:///C:/folder/file"
         # or "file:///C:\\dir\\file"
         path = path[1:]
+    if path.startswith("\\\\"):
+        # special case for windows UNC/DFS-style paths, do nothing, jsut flip the slashes around (case below does not work!)
+        return path.replace("\\", "/")
     if path.startswith("\\") or re.match("[\\\\]*[A-Za-z]:", path):
         # windows full path "\\server\\path" or "C:\\local\\path"
         return path.lstrip("\\").replace("\\", "/").replace("//", "/")

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -389,7 +389,7 @@ def test_make_path_posix():
     assert make_path_posix("relpath", sep="/") == os.path.join(cwd, "relpath")
     assert make_path_posix("rel/path", sep="/") == os.path.join(cwd, "rel/path")
     assert make_path_posix("C:\\path", sep="\\") == "C:/path"
-    assert make_path_posix(r'\\windows-server\someshare\path\more\path\dir\foo.parquet') == r'//windows-server/someshare/path/more/path/dir/foo.parquet'
+    assert make_path_posix('\\\\windows-server\\someshare\\path\\more\\path\dir\\foo.parquet') == '//windows-server/someshare/path/more/path/dir/foo.parquet'
     assert "/" in make_path_posix("rel\\path", sep="\\")
 
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -388,7 +388,8 @@ def test_make_path_posix():
     assert make_path_posix("/posix") == "/posix"
     assert make_path_posix("relpath", sep="/") == os.path.join(cwd, "relpath")
     assert make_path_posix("rel/path", sep="/") == os.path.join(cwd, "rel/path")
-    assert make_path_posix("C:\\path", sep="\\") == "C:/path"
+    assert make_path_posix("C:\\path", sep="\\") == " C: / path "
+    assert make_path_posix(r'\\windows-server\someshare\path\more\path\dir\foo.parquet') == r'//windows-server/someshare/path/more/path/dir/foo.parquet'
     assert "/" in make_path_posix("rel\\path", sep="\\")
 
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -389,7 +389,7 @@ def test_make_path_posix():
     assert make_path_posix("relpath", sep="/") == os.path.join(cwd, "relpath")
     assert make_path_posix("rel/path", sep="/") == os.path.join(cwd, "rel/path")
     assert make_path_posix("C:\\path", sep="\\") == "C:/path"
-    assert make_path_posix('\\\\windows-server\\someshare\\path\\more\\path\dir\\foo.parquet') == '//windows-server/someshare/path/more/path/dir/foo.parquet'
+    assert make_path_posix("\\\\windows-server\\someshare\\path\\more\\path\dir\\foo.parquet") == "//windows-server/someshare/path/more/path/dir/foo.parquet"
     assert "/" in make_path_posix("rel\\path", sep="\\")
 
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -388,7 +388,7 @@ def test_make_path_posix():
     assert make_path_posix("/posix") == "/posix"
     assert make_path_posix("relpath", sep="/") == os.path.join(cwd, "relpath")
     assert make_path_posix("rel/path", sep="/") == os.path.join(cwd, "rel/path")
-    assert make_path_posix("C:\\path", sep="\\") == " C: / path "
+    assert make_path_posix("C:\\path", sep="\\") == "C:/path"
     assert make_path_posix(r'\\windows-server\someshare\path\more\path\dir\foo.parquet') == r'//windows-server/someshare/path/more/path/dir/foo.parquet'
     assert "/" in make_path_posix("rel\\path", sep="\\")
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -389,7 +389,12 @@ def test_make_path_posix():
     assert make_path_posix("relpath", sep="/") == os.path.join(cwd, "relpath")
     assert make_path_posix("rel/path", sep="/") == os.path.join(cwd, "rel/path")
     assert make_path_posix("C:\\path", sep="\\") == "C:/path"
-    assert make_path_posix("\\\\windows-server\\someshare\\path\\more\\path\dir\\foo.parquet") == "//windows-server/someshare/path/more/path/dir/foo.parquet"
+    assert (
+        make_path_posix(
+            "\\\\windows-server\\someshare\\path\\more\\path\dir\\foo.parquet"
+        )
+        == "//windows-server/someshare/path/more/path/dir/foo.parquet"
+    )
     assert "/" in make_path_posix("rel\\path", sep="\\")
 
 


### PR DESCRIPTION
Treatement of UNC/DFS paths on windows removes the leading \\. Path \\aaa\bbb\ccc\ddd.txt becomes aaa/bbb/ccc/ddd.txt which cause errors in Dask file access.

UNC \\... and filesystem x:\ handing was combined, I added some logic which handles \\... paths first by simply posix-ifying the path resulting in //aaa/bbb/ccc/ddd.txt