### PR TITLE
FTPFileSystem Fall back to using `dir` when `mlsd`extension is not avail on server

### DIFF
--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -124,6 +124,7 @@ class FTPFileSystem(AbstractFileSystem):
             out = [f for f in files if f["name"] == path][0]
         except IndexError:
             raise FileNotFoundError(path)
+        return out
 
     def _open(self, path, mode="rb", block_size=None, autocommit=True, **kwargs):
         path = self._strip_protocol(path)

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -215,7 +215,7 @@ class FTPFile(AbstractBufferedFile):
             try:
                 self.fs.ftp.voidresp()
             except timeout:
-                pass
+                self.fs._connect()
         return b"".join(out)
 
     def _upload_chunk(self, final=False):

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -1,4 +1,5 @@
-from ftplib import FTP, Error
+from ftplib import FTP, Error, error_perm
+from socket import timeout
 import uuid
 from ..spec import AbstractBufferedFile, AbstractFileSystem
 from ..utils import infer_storage_options
@@ -19,6 +20,7 @@ class FTPFileSystem(AbstractFileSystem):
         acct=None,
         block_size=None,
         tempdir="/tmp",
+        timeout=30,
         **kwargs
     ):
         """
@@ -50,12 +52,15 @@ class FTPFileSystem(AbstractFileSystem):
         self.port = port
         self.tempdir = tempdir
         self.cred = username, password, acct
+        self.timeout = timeout
         if block_size is not None:
             self.blocksize = block_size
+        else:
+            self.blocksize = 2 ** 16
         self._connect()
 
     def _connect(self):
-        self.ftp = FTP()
+        self.ftp = FTP(timeout=self.timeout)
         self.ftp.connect(self.host, self.port)
         self.ftp.login(*self.cred)
 
@@ -88,7 +93,7 @@ class FTPFileSystem(AbstractFileSystem):
                         if fn not in [".", ".."]
                         and details["type"] not in ["pdir", "cdir"]
                     ]
-                except Error:
+                except error_perm:
                     out = _mlsd2(self.ftp, path)  # Not platform independent
                 for fn, details in out:
                     if path == "/":
@@ -180,7 +185,7 @@ class FTPFile(AbstractBufferedFile):
         Implemented by raising an exception in the fetch callback when the
         number of bytes received reaches the requested amount.
 
-        With fail if the server does not respect the REST command on
+        Will fail if the server does not respect the REST command on
         retrieve requests.
         """
         out = []
@@ -200,17 +205,19 @@ class FTPFile(AbstractBufferedFile):
 
         try:
             self.fs.ftp.retrbinary(
-                "RETR %s" % self.path, blocksize=2 ** 16, rest=start, callback=callback
+                "RETR %s" % self.path, blocksize=self.blocksize, rest=start, callback=callback
             )
         except TransferDone:
             self.fs.ftp.abort()
-            self.fs.ftp.voidresp()
+            try:
+                self.fs.ftp.voidresp()
+            except timeout: pass
         return b"".join(out)
 
     def _upload_chunk(self, final=False):
         self.buffer.seek(0)
         self.fs.ftp.storbinary(
-            "STOR " + self.path, self.buffer, blocksize=2 ** 16, rest=self.offset
+            "STOR " + self.path, self.buffer, blocksize=self.blocksize, rest=self.offset
         )
         return True
 

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -205,13 +205,17 @@ class FTPFile(AbstractBufferedFile):
 
         try:
             self.fs.ftp.retrbinary(
-                "RETR %s" % self.path, blocksize=self.blocksize, rest=start, callback=callback
+                "RETR %s" % self.path,
+                blocksize=self.blocksize,
+                rest=start,
+                callback=callback,
             )
         except TransferDone:
             self.fs.ftp.abort()
             try:
                 self.fs.ftp.voidresp()
-            except timeout: pass
+            except timeout:
+                pass
         return b"".join(out)
 
     def _upload_chunk(self, final=False):


### PR DESCRIPTION
Not sure if it necessary to try to match the format of the extra **details** from `mlsd` command, so I haven't done that here (unix users/groups, permissions, unique, etc.). `dir` output is dependent on the server platform, but I have assumed Linux `ls -l` format to be the most common and it solves the issues I ran into. 

Also, I had to tweak the `_parent` call in `info` to strip a double forward slash (`//`) that seemed to crop up.  Tests seem to continue to pass, but now the following things all seem to work.

```python
host = fsspec.filesystem('ftp', host='ftpprd.ncep.noaa.gov')  
host.ls("/")   

host = fsspec.filesystem('ftp', host='ngs.sanger.ac.uk')  
host.get("scratch/README", "test.readme.txt")

fs = fsspec.filesystem('ftp', host="ftpprd.ncep.noaa.gov")
with fs.open("ftp://ftpprd.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20191020/18/gfs.t18z.aircft.tm00.bufr_d.nr", "rb") as f:
    with open("temp", "wb") as nc:
        nc.write(f.read())
```