### PR TITLE
Handle content-length of 0

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -180,7 +180,7 @@ class HTTPFileSystem(AbstractFileSystem):
             # get failed, so conclude URL does not exist
             if size is False:
                 raise FileNotFoundError(url)
-        return {"name": url, "size": size, "type": "file"}
+        return {"name": url, "size": size or None, "type": "file"}
 
 
 class HTTPFile(AbstractBufferedFile):

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -172,7 +172,7 @@ class HTTPFileSystem(AbstractFileSystem):
         for policy in ["head", "get"]:
             try:
                 size = file_size(url, self.session, policy, **self.kwargs)
-                if size is not None:
+                if size:
                     break
             except Exception:
                 pass
@@ -339,11 +339,7 @@ def file_size(url, session=None, size_policy="head", **kwargs):
     else:
         raise TypeError('size_policy must be "head" or "get", got %s' "" % size_policy)
     if "Content-Length" in r.headers:
-        content_length = int(r.headers["Content-Length"])
-        if content_length:
-            # Some servers respond with a Content-Length of 0. We choose to treat these
-            # as not responding with a content-length.
-            return content_length
+        return int(r.headers["Content-Length"])
     elif "Content-Range" in r.headers:
         return int(r.headers["Content-Range"].split("/")[1])
 

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -339,7 +339,11 @@ def file_size(url, session=None, size_policy="head", **kwargs):
     else:
         raise TypeError('size_policy must be "head" or "get", got %s' "" % size_policy)
     if "Content-Length" in r.headers:
-        return int(r.headers["Content-Length"])
+        content_length = int(r.headers["Content-Length"])
+        if content_length:
+            # Some servers respond with a Content-Length of 0. We choose to treat these
+            # as not responding with a content-length.
+            return content_length
     elif "Content-Range" in r.headers:
         return int(r.headers["Content-Range"].split("/")[1])
 

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -37,8 +37,6 @@ class HTTPTestHandler(BaseHTTPRequestHandler):
             d = d[int(start) : int(end) + 1]
         if "give_length" in self.headers:
             response_headers = {"Content-Length": len(d)}
-            if "zero_length" in self.headers:
-                response_headers["Content-Length"] = 0
             self._respond(200, response_headers, d)
         elif "give_range" in self.headers:
             self._respond(200, {"Content-Range": "0-%i/%i" % (len(d) - 1, len(d))}, d)
@@ -154,5 +152,4 @@ def test_content_length_zero(server):
     url = server + "/index/realfile"
 
     with h.open(url, "rb") as f:
-        assert f.size is None
         assert f.read() == data

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -38,7 +38,7 @@ class HTTPTestHandler(BaseHTTPRequestHandler):
         if "give_length" in self.headers:
             response_headers = {"Content-Length": len(d)}
             if "zero_length" in self.headers:
-                response_headers['Content-Length'] = 0
+                response_headers["Content-Length"] = 0
             self._respond(200, response_headers, d)
         elif "give_range" in self.headers:
             self._respond(200, {"Content-Range": "0-%i/%i" % (len(d) - 1, len(d))}, d)
@@ -55,7 +55,7 @@ class HTTPTestHandler(BaseHTTPRequestHandler):
         elif "give_length" in self.headers:
             response_headers = {"Content-Length": len(d)}
             if "zero_length" in self.headers:
-                response_headers['Content-Length'] = 0
+                response_headers["Content-Length"] = 0
 
             self._respond(200, response_headers)
         elif "give_range" in self.headers:
@@ -148,8 +148,9 @@ def test_mapper_url(server):
 
 
 def test_content_length_zero(server):
-    h = fsspec.filesystem("http",
-                          headers={"give_length": "true", "zero_length": "true"})
+    h = fsspec.filesystem(
+        "http", headers={"give_length": "true", "zero_length": "true"}
+    )
     url = server + "/index/realfile"
 
     with h.open(url, "rb") as f:


### PR DESCRIPTION
cc @martindurant.

This test is failing right now. Some layer is truncating the response when the `Content-Length` is 0, so the `assert f.read() == data` is failing. `f.read()` is returning `b''`. Any suggestions on an alternative test?

It is working for the original issue though

```python
In [1]: import dask.dataframe as dd
df
In [2]: df2 = dd.read_csv('https://fred.stlouisfed.org/graph/fredgraph.csv?id=SP500')

In [3]: df2.compute()
Out[3]:
            DATE    SP500
0     2009-10-23  1079.60
1     2009-10-26  1066.95
2     2009-10-27  1063.41
3     2009-10-28  1042.63
4     2009-10-29  1066.11
...          ...      ...
2603  2019-10-16  2989.69
2604  2019-10-17  2997.95
2605  2019-10-18   2986.2
2606  2019-10-21  3006.72
2607  2019-10-22  2995.99

[2608 rows x 2 columns]
```

Closes https://github.com/dask/dask/issues/5517