### PR TITLE
Test leading/non-leading POSIX path slashes

### DIFF
--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -149,6 +149,18 @@ def test_infer_options():
     assert so.pop("path") == "/mnt/datasets/test.csv"
     assert not so
 
+    # POSIX filesystem paths can have duplicate slashes, including at
+    # the beginning
+    so = infer_storage_options("//mnt/datasets/test.csv")
+    assert so.pop("protocol") == "file"
+    assert so.pop("path") == "//mnt/datasets/test.csv"
+    assert not so
+
+    so = infer_storage_options("/mnt//datasets/test.csv")
+    assert so.pop("protocol") == "file"
+    assert so.pop("path") == "/mnt//datasets/test.csv"
+    assert not so
+
     assert infer_storage_options("./test.csv")["path"] == "./test.csv"
     assert infer_storage_options("../test.csv")["path"] == "../test.csv"
 


### PR DESCRIPTION
This adds a test which fails when the following is called:

```python
infer_storage_options("//mnt/datasets/test.csv”)
```

It returns:

```python
{'protocol': 'file', 'path’: '/datasets/test.csv', 'host': ‘mnt’}
```

This corresponds to issue #164.