### PR TITLE
Fixes #169

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -436,13 +436,21 @@ class AbstractFileSystem(up):
         kwargs are passed to ``ls``.
         """
         import re
+        from glob import has_magic
 
         ends = path.endswith("/")
         path = self._strip_protocol(path)
-        indstar = path.find("*") if path.find("*") >= 0 else len(path)
-        indques = path.find("?") if path.find("?") >= 0 else len(path)
+        indstar = path.find("*")
+        indques = path.find("?")
+
+        if indstar < 0:
+            indstar = len(path)
+        if indques < 0:
+            indques = len(path)
+
         ind = min(indstar, indques)
-        if "*" not in path and "?" not in path:
+
+        if not has_magic(path):
             root = path
             depth = 1
             if ends:

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -440,15 +440,11 @@ class AbstractFileSystem(up):
 
         ends = path.endswith("/")
         path = self._strip_protocol(path)
-        indstar = path.find("*")
-        indques = path.find("?")
+        indstar = path.find("*") if path.find("*") >= 0 else len(path)
+        indques = path.find("?") if path.find("?") >= 0 else len(path)
+        indbrace = path.find("[") if path.find("[") >= 0 else len(path)
 
-        if indstar < 0:
-            indstar = len(path)
-        if indques < 0:
-            indques = len(path)
-
-        ind = min(indstar, indques)
+        ind = min(indstar, indques, indbrace)
 
         if not has_magic(path):
             root = path

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -1,0 +1,72 @@
+import pytest
+from fsspec.spec import AbstractFileSystem
+
+
+class TestFS(AbstractFileSystem):
+    protocol = "mock"
+    _fs_contents = (
+        {"name": "top_level/second_level/date=2019-10-01/", "type": "directory"},
+        {"name": "top_level/second_level/date=2019-10-01/a.parquet", "type": "file"},
+        {"name": "top_level/second_level/date=2019-10-01/b.parquet", "type": "file"},
+        {"name": "top_level/second_level/date=2019-10-02/", "type": "directory"},
+        {"name": "top_level/second_level/date=2019-10-02/a.parquet", "type": "file"},
+        {"name": "top_level/second_level/date=2019-10-04/", "type": "directory"},
+        {"name": "top_level/second_level/date=2019-10-04/a.parquet", "type": "file"},
+        {"name": "misc/", "type": "directory"},
+        {"name": "misc/foo.txt", "type": "file"},
+    )
+
+    def ls(self, path, detail=True, **kwargs):
+        files = (file for file in self._fs_contents if path in file["name"])
+
+        if detail:
+            return list(files)
+
+        return list(sorted([file["name"] for file in files]))
+
+
+@pytest.mark.parametrize(
+    "test_path, expected",
+    [
+        (
+            "mock://top_level/second_level/date=2019-10-01/a.parquet",
+            ["top_level/second_level/date=2019-10-01/a.parquet"],
+        ),
+        (
+            "mock://top_level/second_level/date=2019-10-01/*",
+            [
+                "top_level/second_level/date=2019-10-01/a.parquet",
+                "top_level/second_level/date=2019-10-01/b.parquet",
+            ],
+        ),
+        (
+            "mock://top_level/second_level/date=2019-10-0[1-4]",
+            [
+                "top_level/second_level/date=2019-10-01",
+                "top_level/second_level/date=2019-10-02",
+                "top_level/second_level/date=2019-10-04",
+            ],
+        ),
+        (
+            "mock://top_level/second_level/date=2019-10-0[1-4]/*",
+            [
+                "top_level/second_level/date=2019-10-01/a.parquet",
+                "top_level/second_level/date=2019-10-01/b.parquet",
+                "top_level/second_level/date=2019-10-02/a.parquet",
+                "top_level/second_level/date=2019-10-04/a.parquet",
+            ],
+        ),
+        (
+            "mock://top_level/second_level/date=2019-10-0[1-4]/[a].*",
+            [
+                "top_level/second_level/date=2019-10-01/a.parquet",
+                "top_level/second_level/date=2019-10-02/a.parquet",
+                "top_level/second_level/date=2019-10-04/a.parquet",
+            ],
+        ),
+    ],
+)
+def test_glob(test_path, expected):
+    test_fs = TestFS()
+
+    assert test_fs.glob(test_path) == expected


### PR DESCRIPTION
Uses builtin `glob.has_magic` to detect when special characters are used in the string
Separates if-checks for `indstar` and `indques` so that `path.find` is called twice instead of four times
