### PR TITLE
TST: Fixup deprecation warnings

### DIFF
--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -391,7 +391,7 @@ def test_make_path_posix():
     assert make_path_posix("C:\\path", sep="\\") == "C:/path"
     assert (
         make_path_posix(
-            "\\\\windows-server\\someshare\\path\\more\\path\dir\\foo.parquet"
+            "\\\\windows-server\\someshare\\path\\more\\path\\dir\\foo.parquet"
         )
         == "//windows-server/someshare/path/more/path/dir/foo.parquet"
     )

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -2,7 +2,7 @@ import pytest
 from fsspec.spec import AbstractFileSystem
 
 
-class TestFS(AbstractFileSystem):
+class DummyTestFS(AbstractFileSystem):
     protocol = "mock"
     _fs_contents = (
         {"name": "top_level/second_level/date=2019-10-01/", "type": "directory"},
@@ -67,6 +67,6 @@ class TestFS(AbstractFileSystem):
     ],
 )
 def test_glob(test_path, expected):
-    test_fs = TestFS()
+    test_fs = DummyTestFS()
 
     assert test_fs.glob(test_path) == expected


### PR DESCRIPTION
Fixes the following

```
================================================================================= warnings summary ==================================================================================fsspec/implementations/tests/test_local.py:394
  /Users/taugspurger/sandbox/filesystem_spec/fsspec/implementations/tests/test_local.py:394: DeprecationWarning: invalid escape sequence \d
    "\\\\windows-server\\someshare\\path\\more\\path\dir\\foo.parquet"

fsspec/tests/test_spec.py:5
  /Users/taugspurger/sandbox/filesystem_spec/fsspec/tests/test_spec.py:5: PytestCollectionWarning: cannot collect test class 'TestFS' because it has a __init__ constructor (from: fsspec/tests/test_spec.py)
    class TestFS(AbstractFileSystem):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```