### PR TITLE
Write test to explain behaviour of .info

### DIFF
--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -75,3 +75,15 @@ def test_glob(test_path, expected):
 def test_add_docs_warns():
     with pytest.warns(FutureWarning, match="add_docs"):
         AbstractFileSystem(add_docs=True)
+
+
+def test_exists():
+    """ Test calling `exists` and `info` on partially completed file/directory names."""
+    test_fs = DummyTestFS()
+
+    assert test_fs.exists("top_level/second")
+    assert test_fs.exists("top_level/second_level/date/")
+    assert test_fs.exists("top_level/second_level/date=2019-10-01/a.parq")
+
+    info = test_fs.info("top_level/second_level/date=2019-10-01/a.parq")
+    assert info["type"] == "directory"


### PR DESCRIPTION
I am wondering if this behaviour is intended:

Calling: `AbstractFileSystem.exists("top_level/second")` will result in `True` even though the directory only exists as `second_level`.

Calling `AbstractFileSystem.exists("top_level/second_level/date/")` will also result in `True`, even though that does not exist as a directory, but `"top_level/second_level/date"` prefixes other directory names.

Calling `AbstractFileSystem.exists("top_level/second_level/date=2019-10-01/a.parq")` will result in `True`, even though it's doesn't exist as a file, only as a prefix again.

And lastly this results in a strange behaviour when doing the following:

```python
    # This does not exist as a directory, and only prefixes the name of a file
    info = test_fs.info("top_level/second_level/date=2019-10-01/a.parq")
    # Yet returns `type` as a directory.
    assert info["type"] == "directory"
```

My assumption is that this has to do mostly with this line: https://github.com/foxyblue/filesystem_spec/blob/master/fsspec/spec.py#L502 checking for unempty `out` variable.

I found this bug by using doing:

```python
if not FS.exists("directory"):
    FS.mkdir("directory")
if not FS.exists("dir"):
    FS.mkdir("dir")
```
Resulting in only `"directory"` to be created.