### PR TITLE
API: Kwargs handling for Caches

### DIFF
--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -441,7 +441,7 @@ class BaseCache(object):
         How big this file is
     """
 
-    def __init__(self, blocksize, fetcher, size, **kwargs):
+    def __init__(self, blocksize, fetcher, size):
         self.blocksize = blocksize
         self.fetcher = fetcher
         self.size = size
@@ -459,7 +459,7 @@ class MMapCache(BaseCache):
     This cache method might only work on posix
     """
 
-    def __init__(self, blocksize, fetcher, size, location=None, blocks=None, **kwargs):
+    def __init__(self, blocksize, fetcher, size, location=None, blocks=None):
         super().__init__(blocksize, fetcher, size)
         self.blocks = set() if blocks is None else blocks
         self.location = location
@@ -522,7 +522,7 @@ class ReadAheadCache(BaseCache):
     many small reads in a sequential order (e.g., readling lines from a file).
     """
 
-    def __init__(self, blocksize, fetcher, size, **kwargs):
+    def __init__(self, blocksize, fetcher, size):
         super().__init__(blocksize, fetcher, size)
         self.cache = b""
         self.start = 0
@@ -564,7 +564,7 @@ class BytesCache(BaseCache):
         we are more than a blocksize ahead of it.
     """
 
-    def __init__(self, blocksize, fetcher, size, trim=True, **kwargs):
+    def __init__(self, blocksize, fetcher, size, trim=True):
         super().__init__(blocksize, fetcher, size)
         self.cache = b""
         self.start = None

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -921,9 +921,10 @@ class AbstractBufferedFile(io.IOBase):
         if "trim" in kwargs:
             warnings.warn(
                 "Passing 'trim' to control the cache behavior has been deprecated. "
-                "Specify it within the 'cache_options' argument instead."
+                "Specify it within the 'cache_options' argument instead.",
+                FutureWarning,
             )
-            cache_options = kwargs.pop("trim")
+            cache_options["trim"] = kwargs.pop("trim")
 
         self.kwargs = kwargs
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -935,7 +935,7 @@ class AbstractBufferedFile(io.IOBase):
                 self.details = fs.info(path)
             self.size = self.details["size"]
             self.cache = caches[cache_type](
-                self.blocksize, self._fetch_range, self.size, **cache_options,
+                self.blocksize, self._fetch_range, self.size, **cache_options
             )
         else:
             self.buffer = io.BytesIO()

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -128,4 +128,4 @@ def test_cache_options():
 def test_trim_kwarg_warns():
     fs = DummyTestFS()
     with pytest.warns(FutureWarning, match="cache_options"):
-        f = AbstractBufferedFile(fs, "misc/foo.txt", cache_type="bytes", trim=False)
+        AbstractBufferedFile(fs, "misc/foo.txt", cache_type="bytes", trim=False)

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -115,12 +115,12 @@ def test_add_docs_warns():
 
 def test_cache_options():
     fs = DummyTestFS()
-    f = fs.open("/misc/foo.txt")
+    f = fs.open("misc/foo.txt")
     assert f.cache.trim
 
     # TODO: dummy buffered file
     f = AbstractBufferedFile(
-        fs, "/misc/file.txt", cache_type="bytes", cache_options=dict(trim=False)
+        fs, "misc/foo.txt", cache_type="bytes", cache_options=dict(trim=False)
     )
     assert f.cache.trim is False
 
@@ -128,4 +128,4 @@ def test_cache_options():
 def test_trim_kwarg_warns():
     fs = DummyTestFS()
     with pytest.warns(FutureWarning, match="cache_options"):
-        f = AbstractBufferedFile(fs, "/misc/file.txt", cache_type="bytes", trim=False)
+        f = AbstractBufferedFile(fs, "misc/foo.txt", cache_type="bytes", trim=False)


### PR DESCRIPTION
This removes `**kwargs` from the signature of all the byte Cache
classes. The were not being used, and accepting kwargs can lead to
subtle errors.

It also changes how kwargs are forwarded from the opened File to
the cache. We use a dedicated `storage_options` dict, which is
more flexible than popping off specific keywords from `**kwargs`.