### PR TITLE
Add BlockCache

### DIFF
--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -729,7 +729,7 @@ class BytesCache(BaseCache):
         super().__init__(blocksize, fetcher, size)
         self.cache = b""
         self.start = None
-        self.end = -1
+        self.end = None
         self.trim = trim
 
     def _fetch(self, start, end):

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -473,8 +473,12 @@ class BaseCache(object):
         # handle endpoints
         if item.start is None:
             item = slice(0, item.stop)
+        elif item.start < 0:
+            item = slice(self.size + item.start, item.stop)
         if item.stop is None:
             item = slice(item.start, self.size)
+        elif item.stop < 0:
+            item = slice(item.start, self.size + item.stop)
 
         return self._fetch(item.start, item.stop)
 

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -70,7 +70,7 @@ def test_cache_pickleable(Cache_imp):
 
 @pytest.mark.parametrize(
     "size_requests",
-    [[(0, 30), (0, 35), (51, 52),], [(0, 1), (1, 11), (1, 52),], [(0, 52), (11, 15),],],
+    [[(0, 30), (0, 35), (51, 52)], [(0, 1), (1, 11), (1, 52)], [(0, 52), (11, 15)]],
 )
 @pytest.mark.parametrize("blocksize", [1, 10, 52, 100])
 def test_cache_basic(Cache_imp, blocksize, size_requests):

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -102,6 +102,7 @@ def test_cache_getitem(Cache_imp):
     assert cacher[0:4] == b"abcd"
     assert cacher[:4] == b"abcd"
     assert cacher[-3:] == b"XYZ"
+    assert cacher[-3:-1] == b"XY"
     assert cacher[2:4] == b"cd"
 
 

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -2,7 +2,14 @@ import pytest
 import pickle
 import string
 
-from fsspec.core import _expand_paths, OpenFile, caches, get_compression, BaseCache
+from fsspec.core import (
+    _expand_paths,
+    OpenFile,
+    caches,
+    get_compression,
+    BaseCache,
+    BlockCache,
+)
 
 
 @pytest.mark.parametrize(
@@ -97,3 +104,30 @@ def test_cache_getitem_raises():
 
     with pytest.raises(ValueError, match="contiguous"):
         cacher[::4]
+
+
+def test_block_cache_lru():
+    cache = BlockCache(4, letters_fetcher, len(string.ascii_letters), maxblocks=2)
+    # miss
+    cache[0:2]
+    assert cache.cache_info().hits == 0
+    assert cache.cache_info().misses == 1
+    assert cache.cache_info().currsize == 1
+
+    # hit
+    cache[0:2]
+    assert cache.cache_info().hits == 1
+    assert cache.cache_info().misses == 1
+    assert cache.cache_info().currsize == 1
+
+    # miss
+    cache[4:6]
+    assert cache.cache_info().hits == 1
+    assert cache.cache_info().misses == 2
+    assert cache.cache_info().currsize == 2
+
+    # miss & evict
+    cache[12:13]
+    assert cache.cache_info().hits == 1
+    assert cache.cache_info().misses == 3
+    assert cache.cache_info().currsize == 2


### PR DESCRIPTION
An alternative caching implementation that's intended as a replacement for BytesCache. The idea is to only ever make requests of size `blocksize`. At a high-level, the design is

* Cache data in a `Dict[int, bytes]`, a mapping from block number to the bytes for that chunk
* When serving a `fetch_range` request,
  * determine all the blocks touched by start, end, and in between
  * Make actual get requests for uncached blocks
  * Return the requested bytes by slicing the blocks and joining

---

I was kicking around this idea a couple months ago when we were hitting bugs in BytesCache, which has some surprisingly complicated logic.

This implementation tries to get similar characteristics (cache reads as in-memory bytestrings).

I think the main thing to decide is whether we should have some kind of `maxsize` parameter to control how large this cache will get. Right now, we'll end up caching the full contents of the file if a byte has been requested from every chunk. We could cap that somehow, and evict blocks based on some strategy (least recently used, used the least number of times, etc.)

cc @martindurant if you have a chance to look, though not a priority. I need to do some performance testing / profiling.