### PR TITLE
API: Change the default caching to readahead

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -872,7 +872,7 @@ class AbstractBufferedFile(io.IOBase):
         mode="rb",
         block_size="default",
         autocommit=True,
-        cache_type="bytes",
+        cache_type="readahead",
         cache_options=None,
         **kwargs
     ):
@@ -892,9 +892,8 @@ class AbstractBufferedFile(io.IOBase):
         autocommit: bool
             Whether to write to final destination; may only impact what
             happens when file is being closed.
-        cache_type: str
-            Caching policy in read mode, one of 'none', 'bytes', 'mmap', see
-            the definitions in ``core``.
+        cache_type: {"readahead", "none", "mmap", "bytes"}, default "readahead"
+            Caching policy in read mode. See the definitions in ``core``.
         cache_options : dict
             Additional options passed to the constructor for the cache specified
             by `cache_type`.

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -115,7 +115,7 @@ def test_add_docs_warns():
 
 def test_cache_options():
     fs = DummyTestFS()
-    f = fs.open("misc/foo.txt")
+    f = AbstractBufferedFile(fs, "misc/foo.txt", cache_type="bytes")
     assert f.cache.trim
 
     # TODO: dummy buffered file


### PR DESCRIPTION
xref https://github.com/intake/filesystem_spec/pull/191.

The BytesCache cache is complex and has been the source of bugs in the past. This switches over to the simpler readahead cache by default.

This cache is worse for workloads where you're likely to re-read an earlier part of the file, as those contents would have been dropped from the cache.

The previous behavior can be restored with `cache_type='bytes'` when creating a File (a config to switch this would be nice).


