### PR TITLE
Add `cache_options` to AbstractFileSystem._open subclasses

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -200,7 +200,14 @@ class CachingFileSystem(AbstractFileSystem):
         if not path.startswith(self.protocol):
             path = self.protocol + "://" + path
         if mode != "rb":
-            return self.fs._open(path, mode=mode, **kwargs)
+            return self.fs._open(
+                path,
+                mode=mode,
+                block_size=block_size,
+                autocommit=autocommit,
+                cache_options=cache_options,
+                **kwargs
+            )
         detail, fn = self._check_file(path)
         if detail:
             # file is in cache
@@ -223,11 +230,17 @@ class CachingFileSystem(AbstractFileSystem):
             }
             self.cached_files[-1][path] = detail
             logger.debug("Creating local sparse file for %s" % path)
-        kwargs["cache_type"] = "none"
-        kwargs["mode"] = mode
 
         # call target filesystems open
-        f = self.fs._open(path, **kwargs)
+        f = self.fs._open(
+            path,
+            mode=mode,
+            block_size=block_size,
+            autocommit=autocommit,
+            cache_options=cache_options,
+            cache_type=None,
+            **kwargs
+        )
         if "blocksize" in detail:
             if detail["blocksize"] != f.blocksize:
                 raise ValueError(

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -175,7 +175,15 @@ class CachingFileSystem(AbstractFileSystem):
                 return detail, fn
         return False, None
 
-    def _open(self, path, mode="rb", **kwargs):
+    def _open(
+        self,
+        path,
+        mode="rb",
+        block_size=None,
+        autocommit=True,
+        cache_options=None,
+        **kwargs
+    ):
         """Wrap the target _open
 
         If the whole file exists in the cache, just open it locally and

--- a/fsspec/implementations/dask.py
+++ b/fsspec/implementations/dask.py
@@ -72,7 +72,15 @@ class DaskWorkerFileSystem(AbstractFileSystem):
         else:
             return self.rfs.ls(*args, **kwargs).compute()
 
-    def _open(self, path, mode="rb", **kwargs):
+    def _open(
+        self,
+        path,
+        mode="rb",
+        block_size=None,
+        autocommit=True,
+        cache_options=None,
+        **kwargs
+    ):
         if self.worker:
             return self.fs._open(path, mode=mode)
         else:

--- a/fsspec/implementations/dask.py
+++ b/fsspec/implementations/dask.py
@@ -26,7 +26,7 @@ class DaskWorkerFileSystem(AbstractFileSystem):
         self.remote_options = remote_options
         self.worker = None
         self.client = None
-        self.fs = None
+        self.fs = None  # What is the type here?
         self._determine_worker()
 
     def _determine_worker(self):
@@ -82,9 +82,24 @@ class DaskWorkerFileSystem(AbstractFileSystem):
         **kwargs
     ):
         if self.worker:
-            return self.fs._open(path, mode=mode)
+            return self.fs._open(
+                path,
+                mode=mode,
+                block_size=block_size,
+                autocommit=autocommit,
+                cache_options=cache_options,
+                **kwargs
+            )
         else:
-            return DaskFile(self, path, mode, **kwargs)
+            return DaskFile(
+                self,
+                path,
+                mode,
+                block_size=block_size,
+                autocommit=autocommit,
+                cache_options=cache_options,
+                **kwargs
+            )
 
     def fetch_range(self, path, mode, start, end):
         if self.worker:
@@ -96,26 +111,6 @@ class DaskWorkerFileSystem(AbstractFileSystem):
 
 
 class DaskFile(AbstractBufferedFile):
-    def __init__(
-        self,
-        fs,
-        path,
-        mode="rb",
-        block_size="default",
-        autocommit=True,
-        cache_type="bytes",
-        **kwargs
-    ):
-        super().__init__(
-            fs,
-            path,
-            mode=mode,
-            block_size=block_size,
-            autocommit=autocommit,
-            cache_type=cache_type,
-            **kwargs
-        )
-
     def _upload_chunk(self, final=False):
         pass
 

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -180,9 +180,28 @@ class TransferDone(Exception):
 class FTPFile(AbstractBufferedFile):
     """Interact with a remote FTP file with read/write buffering"""
 
-    def __init__(self, fs, path, **kwargs):
-        super().__init__(fs, path, **kwargs)
-        if kwargs.get("autocommit", False) is False:
+    def __init__(
+        self,
+        fs,
+        path,
+        mode="rb",
+        block_size="default",
+        autocommit=True,
+        cache_type="readahead",
+        cache_options=None,
+        **kwargs
+    ):
+        super().__init__(
+            fs,
+            path,
+            mode=mode,
+            block_size=block_size,
+            autocommit=autocommit,
+            cache_type=cache_type,
+            cache_options=cache_options,
+            **kwargs
+        )
+        if not autocommit:
             self.target = self.path
             self.path = "/".join([kwargs["tempdir"], str(uuid.uuid4())])
 

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -126,7 +126,15 @@ class FTPFileSystem(AbstractFileSystem):
             raise FileNotFoundError(path)
         return out
 
-    def _open(self, path, mode="rb", block_size=None, autocommit=True, **kwargs):
+    def _open(
+        self,
+        path,
+        mode="rb",
+        block_size=None,
+        cache_options=None,
+        autocommit=True,
+        **kwargs
+    ):
         path = self._strip_protocol(path)
         block_size = block_size or self.blocksize
         return FTPFile(
@@ -136,6 +144,7 @@ class FTPFileSystem(AbstractFileSystem):
             block_size=block_size,
             tempdir=self.tempdir,
             autocommit=autocommit,
+            cache_options=cache_options,
         )
 
     def _rm(self, path):

--- a/fsspec/implementations/github.py
+++ b/fsspec/implementations/github.py
@@ -59,7 +59,15 @@ class GithubFileSystem(AbstractFileSystem):
         else:
             return sorted([f["name"] for f in self.dircache[path]])
 
-    def _open(self, path, mode="rb", cache_options=None, **kwargs):
+    def _open(
+        self,
+        path,
+        mode="rb",
+        block_size=None,
+        autocommit=True,
+        cache_options=None,
+        **kwargs
+    ):
         if mode != "rb":
             raise NotImplementedError
         url = self.rurl.format(org=self.org, repo=self.repo, path=path, sha=self.root)

--- a/fsspec/implementations/github.py
+++ b/fsspec/implementations/github.py
@@ -59,7 +59,7 @@ class GithubFileSystem(AbstractFileSystem):
         else:
             return sorted([f["name"] for f in self.dircache[path]])
 
-    def _open(self, path, mode="rb", **kwargs):
+    def _open(self, path, mode="rb", cache_options=None, **kwargs):
         if mode != "rb":
             raise NotImplementedError
         url = self.rurl.format(org=self.org, repo=self.repo, path=path, sha=self.root)

--- a/fsspec/implementations/hdfs.py
+++ b/fsspec/implementations/hdfs.py
@@ -77,8 +77,7 @@ class PyArrowHDFS(AbstractFileSystem):
         -------
         HDFSFile file-like instance
         """
-        if not autocommit:
-            raise NotImplementedError
+
         return HDFSFile(
             self,
             path,
@@ -192,6 +191,12 @@ class HDFSFile(object):
         cache_options=None,
         **kwargs
     ):
+        # TODO: Inherit from AbstractBufferedFile?
+        if not autocommit:
+            raise NotImplementedError(
+                "HDFSFile cannot be opened with 'autocommit=False'."
+            )
+
         self.fs = fs
         self.path = path
         self.mode = mode

--- a/fsspec/implementations/hdfs.py
+++ b/fsspec/implementations/hdfs.py
@@ -50,7 +50,15 @@ class PyArrowHDFS(AbstractFileSystem):
             extra_conf=extra_conf,
         )
 
-    def _open(self, path, mode="rb", block_size=None, autocommit=True, **kwargs):
+    def _open(
+        self,
+        path,
+        mode="rb",
+        block_size=None,
+        autocommit=True,
+        cache_options=None,
+        **kwargs
+    ):
         """
 
         Parameters
@@ -71,7 +79,15 @@ class PyArrowHDFS(AbstractFileSystem):
         """
         if not autocommit:
             raise NotImplementedError
-        return HDFSFile(self, path, mode, block_size, **kwargs)
+        return HDFSFile(
+            self,
+            path,
+            mode,
+            block_size=block_size,
+            autocommit=autocommit,
+            cache_options=cache_options,
+            **kwargs
+        )
 
     def __reduce_ex__(self, protocol):
         return PyArrowHDFS, self.pars
@@ -165,7 +181,17 @@ class HDFSFile(object):
     Allows seek beyond EOF and (eventually) commit/discard
     """
 
-    def __init__(self, fs, path, mode, block_size, **kwargs):
+    def __init__(
+        self,
+        fs,
+        path,
+        mode,
+        block_size,
+        autocommit=True,
+        cache_type="readahead",
+        cache_options=None,
+        **kwargs
+    ):
         self.fs = fs
         self.path = path
         self.mode = mode

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -124,12 +124,20 @@ class HTTPFileSystem(AbstractFileSystem):
         except requests.HTTPError:
             return False
 
-    def _open(self, url, mode="rb", block_size=None, cache_options=None, **kwargs):
+    def _open(
+        self,
+        path,
+        mode="rb",
+        block_size=None,
+        autocommit=None,  # XXX: This differs from the base class.
+        cache_options=None,
+        **kwargs
+    ):
         """Make a file-like object
 
         Parameters
         ----------
-        url: str
+        path: str
             Full URL with protocol
         mode: string
             must be "rb"
@@ -143,15 +151,20 @@ class HTTPFileSystem(AbstractFileSystem):
             raise NotImplementedError
         block_size = block_size if block_size is not None else self.block_size
         kw = self.kwargs.copy()
-        kw.update(kwargs)
-        kw.pop("autocommit", None)
+        kw.update(kwargs)  # this does nothing?
         if block_size:
             return HTTPFile(
-                self, url, self.session, block_size, cache_options=cache_options, **kw
+                self,
+                path,
+                self.session,
+                block_size,
+                mode=mode,
+                cache_options=cache_options,
+                **kw
             )
         else:
             kw["stream"] = True
-            r = self.session.get(url, **kw)
+            r = self.session.get(path, **kw)
             r.raise_for_status()
             r.raw.decode_content = True
             return r.raw

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -98,16 +98,15 @@ class MemoryFileSystem(AbstractFileSystem):
     def exists(self, path):
         return path in self.store
 
-    def _open(self, path, mode="rb", **kwargs):
-        """Make a file-like object
-
-        Parameters
-        ----------
-        path: str
-            identifier
-        mode: str
-            normally "rb", "wb" or "ab"
-        """
+    def _open(
+        self,
+        path,
+        mode="rb",
+        block_size=None,
+        autocommit=True,
+        cache_options=None,
+        **kwargs
+    ):
         if mode in ["rb", "ab", "rb+"]:
             if path in self.store:
                 f = self.store[path]

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -105,7 +105,15 @@ class ZipFileSystem(AbstractFileSystem):
     def cat(self, path):
         return self.zip.read(path)
 
-    def _open(self, path, mode="rb", **kwargs):
+    def _open(
+        self,
+        path,
+        mode="rb",
+        block_size=None,
+        autocommit=True,
+        cache_options=None,
+        **kwargs
+    ):
         path = self._strip_protocol(path)
         if mode != "rb":
             raise NotImplementedError


### PR DESCRIPTION
Confirmed that the dask HDFS tests are passing with this.

See https://github.com/intake/filesystem_spec/issues/201 for more work to be done along this line.

Closes https://github.com/intake/filesystem_spec/issues/198

cc @jrbourbeau