### PR TITLE
Skip ftp tests if unavailable.

### DIFF
--- a/fsspec/implementations/tests/test_ftp.py
+++ b/fsspec/implementations/tests/test_ftp.py
@@ -13,6 +13,7 @@ here = os.path.dirname(os.path.abspath(__file__))
 
 @pytest.fixture()
 def ftp():
+    pytest.importorskip("pyftpdlib")
     P = subprocess.Popen(
         [sys.executable, "-m", "pyftpdlib", "-d", here],
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
As done in the `ftp_writable` fixture.