### PR TITLE
Deprecate auto_mkdir default value

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -4,6 +4,7 @@ import shutil
 import posixpath
 import re
 import tempfile
+import warnings
 from fsspec import AbstractFileSystem
 from fsspec.utils import stringify_path
 
@@ -21,8 +22,16 @@ class LocalFileSystem(AbstractFileSystem):
 
     root_marker = "/"
 
-    def __init__(self, auto_mkdir=True, **kwargs):
+    def __init__(self, auto_mkdir=None, **kwargs):
         super().__init__(**kwargs)
+        if auto_mkdir is None:
+            warnings.warn(
+                "The default value of auto_mkdir=True has been deprecated "
+                "and will be changed to auto_mkdir=False by default in a "
+                "future release.",
+                FutureWarning,
+            )
+            auto_mkdir = True
         self.auto_mkdir = auto_mkdir
 
     def mkdir(self, path, create_parents=True, **kwargs):

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -432,3 +432,10 @@ def test_links(tmpdir):
 def test_isfilestore():
     fs = LocalFileSystem(auto_mkdir=False)
     assert fs._isfilestore()
+
+
+def test_auto_mkdir_warns():
+    # Ensure we're not pulling from instance cache
+    LocalFileSystem.clear_instance_cache()
+    with pytest.warns(FutureWarning, match="auto_mkdir=True has been deprecated"):
+        LocalFileSystem()


### PR DESCRIPTION
Currently we're still falling back to the current behavior of `auto_mkdir=True` if `auto_mkdir` is not specified. I'm not sure how quickly we can move to setting `auto_mkdir=False` by default. Is doing that in this PR too soon, or should we wait for a release with a `FutureWarning`?

Closes #212