### PR TITLE
tests: fix listdir sorting instability

### DIFF
--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -260,7 +260,7 @@ def test_filecache_multicache_with_same_file_different_data_reads_from_first():
     assert fs.cat(f1) == data * 2
 
     # the filenames in each cache are the same, but the data is different
-    assert os.listdir(cache1) == os.listdir(cache2)
+    assert sorted(os.listdir(cache1)) == sorted(os.listdir(cache2))
 
     fs = fsspec.filesystem(
         "filecache", target_protocol="file", cache_storage=[cache1, cache2]


### PR DESCRIPTION
The filesystem gives no guarantee how files in two directories are ordered.

        # the filenames in each cache are the same, but the data is different
>       assert os.listdir(cache1) == os.listdir(cache2)
E       AssertionError: assert ['d5ab5d3de20...2ba', 'cache'] == ['cache', 'd5...f00d04f152ba']
E         At index 0 diff: 'd5ab5d3de205324fbd07a48bc1f8cce33fffbb450198966e1524f00d04f152ba' != 'cache'
E         Use -v to get the full diff