### PR TITLE
Update LocalFileSystem to expand user home directory

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -135,6 +135,7 @@ class LocalFileSystem(AbstractFileSystem):
         path = stringify_path(path)
         if path.startswith("file://"):
             path = path[7:]
+        path = os.path.expanduser(path)
         return make_path_posix(path)
 
     def _isfilestore(self):

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -6,6 +6,7 @@ import os.path
 import sys
 from contextlib import contextmanager
 import tempfile
+import getpass
 
 import pytest
 import fsspec
@@ -439,3 +440,11 @@ def test_auto_mkdir_warns():
     LocalFileSystem.clear_instance_cache()
     with pytest.warns(FutureWarning, match="auto_mkdir=True has been deprecated"):
         LocalFileSystem()
+
+
+def test_strip_protocol_expanduser():
+    path = "file:///C:\\foo\\bar" if sys.platform == "win32" else "file://~/foo/bar"
+    stripped = LocalFileSystem._strip_protocol(path)
+    assert path != stripped
+    assert "file://" not in stripped
+    assert getpass.getuser() in stripped

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -443,7 +443,7 @@ def test_auto_mkdir_warns():
 
 
 def test_strip_protocol_expanduser():
-    path = "file:///C:\\foo\\bar" if sys.platform == "win32" else "file://~/foo/bar"
+    path = "file://~\\foo\\bar" if sys.platform == "win32" else "file://~/foo/bar"
     stripped = LocalFileSystem._strip_protocol(path)
     assert path != stripped
     assert "file://" not in stripped


### PR DESCRIPTION
This PR updates `LocalFileSystem._strip_protocol` to expand `"~"` with the full user home directory path. This allows us to handle local paths like `"~/foo/bar/baz.csv"`

Following up on the conversation in https://github.com/dask/dask/issues/5819