### PR TITLE
fix relative path recursive put

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -634,8 +634,9 @@ class AbstractFileSystem(up, metaclass=_Cached):
             else:
                 # copy lpath as rpath directory
                 rpath2 = rpath
+            lpath2 = make_path_posix(os.path.abspath(lpath))
             rpaths = [
-                posixpath.join(rpath2, path[len(lpath) :].lstrip("/"))
+                posixpath.join(rpath2, path[len(lpath2) :].lstrip("/"))
                 for path in lpaths
             ]
         else:


### PR DESCRIPTION
There seems to be an issue with recursive put that can cause issues like:
```
FS.put("relative/path/dir", "/remote", recursive=True)
FS.find("/remote") == ["/remote/e/path/dir/file1.txt", "/remote/e/path/dir/file2.txt"]
```
This is due follow lines (637-640) from `fsspec.spec`:
```
rpaths = [
    posixpath.join(rpath2, path[len(lpath) :].lstrip("/"))
    for path in lpaths
]
```
`lpaths` are absolute posix paths like `/absolute/relative/path/dir/file1.txt`. While `lpath` is the unmodified input `lpath` which can be like `relative/path/dir`. This results in a corresponding rpath of `/remote/e/path/dir/file1.txt`.

This would also affect certain absolute paths in windows.
```
lpath = r"C:\\some\\windows\\dir"
lpaths = ["C:/some/windows/dir/file1.txt", "C:/some/windows/dir/file2.txt"]  # is changed to posix via 'make_path_posix'
rpath2 = "/remote"
rpaths = [
    posixpath.join(rpath2, path[len(lpath) :].lstrip("/"))
    for path in lpaths
]
rpaths == ["/remote/le1.txt", "/remote/le2.txt"]
```

The following "one-line" change should fix both these scenarios and also `lpath`s like `../parent/path`.

Also added a couple of tests for this. One that tests `FS.put("dirbasename", "/remote", recursive=True)`, and another that tests recursive put on current directory: `FS.put(".", "/remote", recursive=True)`.

