### PR TITLE
WebHDFS - Support some intricacies of HttpFS

### DIFF
--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -226,10 +226,14 @@ class WebHDFS(AbstractFileSystem):
     def ukey(self, path):
         """Checksum info of file, giving method and result"""
         out = self._call("GETFILECHECKSUM", path=path, redirect=False)
-        location = self._apply_proxy(out.headers["Location"])
-        out2 = self.session.get(location)
-        out2.raise_for_status()
-        return out2.json()["FileChecksum"]
+        if "Location" in out.headers:
+            location = self._apply_proxy(out.headers["Location"])
+            out2 = self.session.get(location)
+            out2.raise_for_status()
+            return out2.json()["FileChecksum"]
+        else:
+            out.raise_for_status()
+            return out.json()["FileChecksum"]
 
     def home_directory(self):
         """Get user's home directory"""
@@ -352,7 +356,11 @@ class WebHDFile(AbstractBufferedFile):
             This is the last block, so should complete file, if
             self.autocommit is True.
         """
-        out = self.fs.session.post(self.location, data=self.buffer.getvalue())
+        out = self.fs.session.post(
+            self.location,
+            data=self.buffer.getvalue(),
+            headers={"content-type": "application/octet-stream"},
+        )
         out.raise_for_status()
         return True
 
@@ -369,7 +377,9 @@ class WebHDFile(AbstractBufferedFile):
         location = self.fs._apply_proxy(out.headers["Location"])
         if "w" in self.mode:
             # create empty file to append to
-            out2 = self.fs.session.put(location)
+            out2 = self.fs.session.put(
+                location, headers={"content-type": "application/octet-stream"}
+            )
             out2.raise_for_status()
         self.location = location.replace("CREATE", "APPEND")
 
@@ -378,9 +388,12 @@ class WebHDFile(AbstractBufferedFile):
             "OPEN", path=self.path, offset=start, length=end - start, redirect=False
         )
         out.raise_for_status()
-        location = out.headers["Location"]
-        out2 = self.fs.session.get(self.fs._apply_proxy(location))
-        return out2.content
+        if "Location" in out.headers:
+            location = out.headers["Location"]
+            out2 = self.fs.session.get(self.fs._apply_proxy(location))
+            return out2.content
+        else:
+            return out.content
 
     def commit(self):
         self.fs.mv(self.path, self.target)


### PR DESCRIPTION
Attempting to add support in webhdfs to some intricacies of [HttpFS]( https://hadoop.apache.org/docs/current/hadoop-hdfs-httpfs/index.html).

[Create and write to a file]( https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Create_and_Write_to_a_File) and [append to a File]( https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Append_to_a_File) both require request header "content-type" with value "application/octet-stream". You will get the following error message if you do not set it: “_HTTP Status 400 - Data upload requests must have content-type set to application/octet-stream_”. Set the content-type always to application/octet-stream for the above requests.

[Open and read a file]( https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Open_and_Read_a_File) and [get file checksum]( https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Get_File_Checksum) “usually” redirect the request.  However HttpFS does not seem to redirect (even if noredirect flag is not set) meaning there is no Location response header. For these requests check if the Location response header is actually returned and use the Location value only if it is returned.
