### PR TITLE
Support WebHDFS overwrite flag in CREATE

### DIFF
--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -376,14 +376,13 @@ class WebHDFile(AbstractBufferedFile):
 
     def _initiate_upload(self):
         """ Create remote file/upload """
+        kwargs = self.kwargs.copy()
         if "a" in self.mode:
             op, method = "APPEND", "POST"
         else:
             op, method = "CREATE", "PUT"
-            if self.fs.exists(self.path):
-                # no "truncate" or "create empty"
-                self.fs.rm(self.path)
-        out = self.fs._call(op, method, self.path, redirect=False, **self.kwargs)
+            kwargs["overwrite"] = "true"
+        out = self.fs._call(op, method, self.path, redirect=False, **kwargs)
         location = self.fs._apply_proxy(out.headers["Location"])
         if "w" in self.mode:
             # create empty file to append to


### PR DESCRIPTION
WebHDFS supports an [overwrite](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Overwrite) flag in the [CREATE](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Create_and_Write_to_a_File) request. If the overwrite flag is set to true and the file exists, then it will be overwritten. Overwrite flag defaults to false. 

If the overwrite flag is used, then it is not necessary to separately check if the file exists and to remove it. This saves 1-2 calls to the WebHDFS API and also keeps the service logs cleaner. 