### PR TITLE
Fix slice assignment during readinto for numpy reads

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1246,7 +1246,8 @@ class AbstractBufferedFile(io.IOBase):
         https://docs.python.org/3/library/io.html#io.RawIOBase.readinto
         """
         data = self.read(len(b))
-        b[: len(data)] = data
+        for i in range(len(data)):
+            b[i] = data[i]
         return len(data)
 
     def readuntil(self, char=b"\n", blocks=None):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1246,8 +1246,7 @@ class AbstractBufferedFile(io.IOBase):
         https://docs.python.org/3/library/io.html#io.RawIOBase.readinto
         """
         data = self.read(len(b))
-        for i in range(len(data)):
-            b[i] = data[i]
+        memoryview(b).cast("B")[: len(data)] = data
         return len(data)
 
     def readuntil(self, char=b"\n", blocks=None):

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -3,6 +3,9 @@ import json
 
 import pytest
 from fsspec.spec import AbstractFileSystem, AbstractBufferedFile
+import fsspec
+
+import numpy as np
 
 
 class DummyTestFS(AbstractFileSystem):
@@ -204,3 +207,30 @@ def test_json():
 
     assert DummyTestFS.from_json(outa) is a
     assert DummyTestFS.from_json(outb) is b
+
+
+@pytest.mark.parametrize(
+    "dt",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.float32,
+        np.float64,
+    ],
+)
+def test_readinto_with_numpy(tmpdir, dt):
+    store_path = str(tmpdir / "test_arr.npy")
+    arr = np.arange(10, dtype=dt)
+    arr.tofile(store_path)
+
+    arr2 = np.empty_like(arr)
+    with fsspec.open(store_path, "rb") as f:
+        f.readinto(arr2)
+
+    assert np.array_equal(arr, arr2)


### PR DESCRIPTION
In short, the slice assignment is failing on `readinto`, replacing with a simple loop and individual item assignment works.

See #277 for more details

Happy to optimize this and writes tests, would love feedback on how to do that.