### PR TITLE
On recursive get, skip directories when writing files.

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -607,11 +607,12 @@ class AbstractFileSystem(up, metaclass=_Cached):
             lpaths = [lpath]
         for lpath, rpath in zip(lpaths, rpaths):
             with self.open(rpath, "rb", **kwargs) as f1:
-                with open(lpath, "wb") as f2:
-                    data = True
-                    while data:
-                        data = f1.read(self.blocksize)
-                        f2.write(data)
+                if not os.path.isdir(lpath):
+                    with open(lpath, "wb") as f2:
+                        data = True
+                        while data:
+                            data = f1.read(self.blocksize)
+                            f2.write(data)
 
     def put(self, lpath, rpath, recursive=False, **kwargs):
         """ Upload file from local """

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -607,7 +607,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
             lpaths = [lpath]
         for lpath, rpath in zip(lpaths, rpaths):
             with self.open(rpath, "rb", **kwargs) as f1:
-                if not os.path.isdir(lpath):
+                if not recursive or not os.path.isdir(lpath):
                     with open(lpath, "wb") as f2:
                         data = True
                         while data:


### PR DESCRIPTION
When using get with recursive=True, I was getting errors on the directory nodes because it was trying to write to them as a files. This fixes the problem.