### PR TITLE
Allow chained URL syntax for get_mapper

### DIFF
--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division, absolute_import
 import io
 import os
 import logging
+import re
 from .compression import compr
 from .utils import (
     infer_compression,
@@ -260,8 +261,9 @@ def _un_chain(path, kwargs):
                 paths = list(paths)
             out.append([paths, protocols[0], kwargs[0]])
         return out
+    x = re.compile(".*[^a-z]+.*")  # test for non protocol-like single word
     bits = (
-        [p if "://" in p else p + "://" for p in path.split("::")]
+        [p if "://" in p or x.match(p) else p + "://" for p in path.split("::")]
         if "::" in path
         else [path]
     )

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -131,6 +131,8 @@ def get_mapper(url, check=False, create=False, **kwargs):
     of the mapper required. All keys will be file-names below this location,
     and their values the contents of each key.
 
+    Also accepts compound URLs like zip::s3://bucket/file.zip , see ``fsspec.open``.
+
     Parameters
     ----------
     url: str

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -625,9 +625,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
                     make_path_posix(os.path.join(dirname, filename))
                     for filename in filelist
                 ]
-            rootdir = make_path_posix(
-                os.path.basename(make_path_posix(lpath).rstrip("/"))
-            )
+            rootdir = os.path.basename(make_path_posix(lpath).rstrip("/"))
             if self.exists(rpath):
                 # copy lpath inside rpath directory
                 rpath2 = posixpath.join(rpath, rootdir)
@@ -644,6 +642,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
             rpaths = [rpath]
         for lpath, rpath in zip(lpaths, rpaths):
             with open(lpath, "rb") as f1:
+                self.mkdirs(os.path.dirname(rpath), exist_ok=True)
                 with self.open(rpath, "wb", **kwargs) as f2:
                     data = True
                     while data:


### PR DESCRIPTION
cc @raphaeldussin , would allow your example to become
```yaml
  temp_zip:
    description: zarr zipstore
    driver: zarr
    args:
      urlpath: 'zip::temp_zip.zip'
      consolidated: False
```