### PR TITLE
Provide explicit way to register implementations

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -38,6 +38,8 @@ Base Classes
    fsspec.core.BaseCache
    fsspec.core.get_fs_token_paths
    fsspec.dircache.DirCache
+   fsspec.registry.ReadOnlyRegistry
+   fsspec.registry.register_implementation
 
 .. autoclass:: fsspec.spec.AbstractFileSystem
    :members:
@@ -61,6 +63,11 @@ Base Classes
 
 .. autoclass:: fsspec.dircache.DirCache
    :members: __init__
+
+.. autoclass:: fsspec.registry.ReadOnlyRegistry
+   :members: __init__
+
+.. autofunction:: fsspec.registry.register_implementation
 
 .. _implementations:
 

--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -1,7 +1,12 @@
 from ._version import get_versions
 
 from .spec import AbstractFileSystem
-from .registry import get_filesystem_class, registry, filesystem, register_implementation
+from .registry import (
+    get_filesystem_class,
+    registry,
+    filesystem,
+    register_implementation,
+)
 from .mapping import FSMap, get_mapper
 from .core import open_files, get_fs_token_paths, open, open_local
 from . import caching
@@ -14,7 +19,7 @@ __all__ = [
     "AbstractFileSystem",
     "FSMap",
     "filesystem",
-    'register_implementation',
+    "register_implementation",
     "get_filesystem_class",
     "get_fs_token_paths",
     "get_mapper",

--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -1,7 +1,7 @@
 from ._version import get_versions
 
 from .spec import AbstractFileSystem
-from .registry import get_filesystem_class, registry, filesystem
+from .registry import get_filesystem_class, registry, filesystem, register_implementation
 from .mapping import FSMap, get_mapper
 from .core import open_files, get_fs_token_paths, open, open_local
 from . import caching
@@ -14,6 +14,7 @@ __all__ = [
     "AbstractFileSystem",
     "FSMap",
     "filesystem",
+    'register_implementation',
     "get_filesystem_class",
     "get_fs_token_paths",
     "get_mapper",

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -18,6 +18,7 @@ class ReadOnlyRegistry(dict):
 
     To add backend implementations, use ``register_implementation``
     """
+
     def __init__(self, target):
         self.target = target
 
@@ -54,18 +55,25 @@ def register_implementation(name, cls, clobber=False, errtxt=None):
         which gets added to known_implementations,
         so the import is deferred until the filesystem is actually used.
     clobber: bool (optional)
-        Whether to overwrite a protocol with the same name; if False, will raise instead.
+        Whether to overwrite a protocol with the same name; if False, will raise
+        instead.
     """
     if isinstance(cls, str):
         if name in known_implementations and clobber is False:
-            raise ValueError("Name (%s) already in the known_implementations and clobber "
-                             "is False" % name)
-        known_implementations[name] = {'class': cls,
-                                       'err': errtxt or "%s import failed for protocol %s" % (cls, name)}
+            raise ValueError(
+                "Name (%s) already in the known_implementations and clobber "
+                "is False" % name
+            )
+        known_implementations[name] = {
+            "class": cls,
+            "err": errtxt or "%s import failed for protocol %s" % (cls, name),
+        }
 
     else:
         if name in registry and clobber is False:
-            raise ValueError("Name (%s) already in the registry and clobber is False" % name)
+            raise ValueError(
+                "Name (%s) already in the registry and clobber is False" % name
+            )
         _registry[name] = cls
 
 
@@ -170,7 +178,7 @@ def get_filesystem_class(protocol):
         try:
             register_implementation(protocol, _import_class(bit["class"]))
         except ImportError as e:
-            raise ImportError(bit['err']) from e
+            raise ImportError(bit["err"]) from e
     cls = registry[protocol]
     if getattr(cls, "protocol", None) in ("abstract", None):
         cls.protocol = protocol

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -57,6 +57,9 @@ def register_implementation(name, cls, clobber=False, errtxt=None):
     clobber: bool (optional)
         Whether to overwrite a protocol with the same name; if False, will raise
         instead.
+    errtxt: str (optional)
+        If given, then a failure to import the given class will result in this
+        text being given.
     """
     if isinstance(cls, str):
         if name in known_implementations and clobber is False:

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -4,11 +4,76 @@ from distutils.version import LooseVersion
 __all__ = ["registry", "get_filesystem_class", "default"]
 
 # mapping protocol: implementation class object
-registry = {}
+_registry = {}  # internal, mutable
+
+
+class ReadOnlyError(TypeError):
+    pass
+
+
+class ReadOnlyRegistry(dict):
+    """Dict-like registry, but immutable
+
+    Maps backend name to implementation class
+
+    To add backend implementations, use ``register_implementation``
+    """
+    def __init__(self, target):
+        self.target = target
+
+    def __getitem__(self, item):
+        return self.target[item]
+
+    def __delitem__(self, key):
+        raise ReadOnlyError
+
+    def __setitem__(self, key, value):
+        raise ReadOnlyError
+
+    def clear(self):
+        raise ReadOnlyError
+
+    def __contains__(self, item):
+        return item in self.target
+
+    def __iter__(self):
+        yield from self.target
+
+
+def register_implementation(name, cls, clobber=False, errtxt=None):
+    """Add implementation class to the registry
+
+    Parameters
+    ----------
+    name: str
+        Protocol name to associate with the class
+    cls: class or str
+        if a class: fsspec-compliant implementation class (normally inherits from
+        ``fsspec.AbstractFileSystem``, gets added straight to the registry. If a
+        str, the full path to an implementation class like package.module.class,
+        which gets added to known_implementations,
+        so the import is deferred until the filesystem is actually used.
+    clobber: bool (optional)
+        Whether to overwrite a protocol with the same name; if False, will raise instead.
+    """
+    if isinstance(cls, str):
+        if name in known_implementations and clobber is False:
+            raise ValueError("Name (%s) already in the known_implementations and clobber "
+                             "is False" % name)
+        known_implementations[name] = {'class': cls,
+                                       'err': errtxt or "%s import failed for protocol %s" % (cls, name)}
+
+    else:
+        if name in registry and clobber is False:
+            raise ValueError("Name (%s) already in the registry and clobber is False" % name)
+        _registry[name] = cls
+
+
+registry = ReadOnlyRegistry(_registry)
 default = "file"
 
 # protocols mapped to the class which implements them. This dict can
-# be dynamically updated.
+# updated with register_implementation
 known_implementations = {
     "file": {"class": "fsspec.implementations.local.LocalFileSystem"},
     "memory": {"class": "fsspec.implementations.memory.MemoryFileSystem"},
@@ -102,7 +167,10 @@ def get_filesystem_class(protocol):
         if protocol not in known_implementations:
             raise ValueError("Protocol not known: %s" % protocol)
         bit = known_implementations[protocol]
-        registry[protocol] = _import_class(bit["class"])
+        try:
+            register_implementation(protocol, _import_class(bit["class"]))
+        except ImportError as e:
+            raise ImportError(bit['err']) from e
     cls = registry[protocol]
     if getattr(cls, "protocol", None) in ("abstract", None):
         cls.protocol = protocol

--- a/fsspec/tests/test_registry.py
+++ b/fsspec/tests/test_registry.py
@@ -1,6 +1,12 @@
 import pytest
-from fsspec.registry import (get_filesystem_class, _registry, registry,
-                             register_implementation, ReadOnlyError, known_implementations)
+from fsspec.registry import (
+    get_filesystem_class,
+    _registry,
+    registry,
+    register_implementation,
+    ReadOnlyError,
+    known_implementations,
+)
 from fsspec.spec import AbstractFileSystem
 
 
@@ -22,12 +28,12 @@ def test_minversion_s3fs(protocol, module, minversion, oldversion, monkeypatch):
 
 def test_registry_readonly():
     get_filesystem_class("file")
-    assert 'file' in registry
-    assert 'file' in list(registry)
+    assert "file" in registry
+    assert "file" in list(registry)
     with pytest.raises(ReadOnlyError):
-        del registry['file']
+        del registry["file"]
     with pytest.raises(ReadOnlyError):
-        registry['file'] = None
+        registry["file"] = None
     with pytest.raises(ReadOnlyError):
         registry.clear()
 
@@ -35,9 +41,9 @@ def test_registry_readonly():
 def test_register_cls():
     try:
         with pytest.raises(ValueError):
-            get_filesystem_class('test')
-        register_implementation('test', AbstractFileSystem)
-        cls = get_filesystem_class('test')
+            get_filesystem_class("test")
+        register_implementation("test", AbstractFileSystem)
+        cls = get_filesystem_class("test")
         assert cls is AbstractFileSystem
     finally:
         _registry.clear()
@@ -46,12 +52,12 @@ def test_register_cls():
 def test_register_str():
     try:
         with pytest.raises(ValueError):
-            get_filesystem_class('test')
-        register_implementation('test', "fsspec.AbstractFileSystem")
+            get_filesystem_class("test")
+        register_implementation("test", "fsspec.AbstractFileSystem")
         assert "test" not in registry
-        cls = get_filesystem_class('test')
+        cls = get_filesystem_class("test")
         assert cls is AbstractFileSystem
         assert "test" in registry
     finally:
         _registry.clear()
-        known_implementations.pop('test', None)
+        known_implementations.pop("test", None)

--- a/fsspec/tests/test_registry.py
+++ b/fsspec/tests/test_registry.py
@@ -16,7 +16,7 @@ def clear_registry():
         yield
     finally:
         _registry.clear()
-        known_implementations.pop('test', None)
+        known_implementations.pop("test", None)
 
 
 @pytest.mark.parametrize(
@@ -73,13 +73,14 @@ def test_register_fail(clear_registry):
     with pytest.raises(ValueError):
         register_implementation("test", "doesntexist.AbstractFileSystem")
 
-    register_implementation("test", "doesntexist.AbstractFileSystem", errtxt="hiho",
-                            clobber=True)
+    register_implementation(
+        "test", "doesntexist.AbstractFileSystem", errtxt="hiho", clobber=True
+    )
     with pytest.raises(ImportError) as e:
         get_filesystem_class("test")
     assert "hiho" in str(e.value)
     register_implementation("test", AbstractFileSystem)
-    
+
     with pytest.raises(ValueError):
         register_implementation("test", AbstractFileSystem)
     register_implementation("test", AbstractFileSystem, clobber=True)

--- a/fsspec/tests/test_registry.py
+++ b/fsspec/tests/test_registry.py
@@ -1,5 +1,7 @@
 import pytest
-from fsspec.registry import get_filesystem_class, registry
+from fsspec.registry import (get_filesystem_class, _registry, registry,
+                             register_implementation, ReadOnlyError, known_implementations)
+from fsspec.spec import AbstractFileSystem
 
 
 @pytest.mark.parametrize(
@@ -7,12 +9,49 @@ from fsspec.registry import get_filesystem_class, registry
     [("s3", "s3fs", "0.3.0", "0.1.0"), ("gs", "gcsfs", "0.3.0", "0.1.0")],
 )
 def test_minversion_s3fs(protocol, module, minversion, oldversion, monkeypatch):
-    registry.clear()
+    _registry.clear()
     mod = pytest.importorskip(module, minversion)
 
     assert get_filesystem_class("s3") is not None
-    registry.clear()
+    _registry.clear()
 
     monkeypatch.setattr(mod, "__version__", oldversion)
     with pytest.raises(RuntimeError, match=minversion):
         get_filesystem_class(protocol)
+
+
+def test_registry_readonly():
+    get_filesystem_class("file")
+    assert 'file' in registry
+    assert 'file' in list(registry)
+    with pytest.raises(ReadOnlyError):
+        del registry['file']
+    with pytest.raises(ReadOnlyError):
+        registry['file'] = None
+    with pytest.raises(ReadOnlyError):
+        registry.clear()
+
+
+def test_register_cls():
+    try:
+        with pytest.raises(ValueError):
+            get_filesystem_class('test')
+        register_implementation('test', AbstractFileSystem)
+        cls = get_filesystem_class('test')
+        assert cls is AbstractFileSystem
+    finally:
+        _registry.clear()
+
+
+def test_register_str():
+    try:
+        with pytest.raises(ValueError):
+            get_filesystem_class('test')
+        register_implementation('test', "fsspec.AbstractFileSystem")
+        assert "test" not in registry
+        cls = get_filesystem_class('test')
+        assert cls is AbstractFileSystem
+        assert "test" in registry
+    finally:
+        _registry.clear()
+        known_implementations.pop('test', None)


### PR DESCRIPTION
Fixes #293 

It would still be good to implement an entrypoints method (althoug that would be even better without the dependency on `entrypoints`, to keep this package clean!)