### PR TITLE
Use dir_cache to return ZipFilesystem info()

### DIFF
--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -49,7 +49,7 @@ class MMapCache(BaseCache):
 
     def __init__(self, blocksize, fetcher, size, location=None, blocks=None):
         super().__init__(blocksize, fetcher, size)
-        self.blocks = set() if blocks is None else blocks
+        self.blocks = set() if blocks is None else set(blocks)
         self.location = location
         self.cache = self._makefile()
 

--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -49,7 +49,7 @@ class MMapCache(BaseCache):
 
     def __init__(self, blocksize, fetcher, size, location=None, blocks=None):
         super().__init__(blocksize, fetcher, size)
-        self.blocks = set() if blocks is None else set(blocks)
+        self.blocks = set() if blocks is None else blocks
         self.location = location
         self.cache = self._makefile()
 

--- a/fsspec/implementations/tests/test_zip.py
+++ b/fsspec/implementations/tests/test_zip.py
@@ -131,8 +131,9 @@ def test_info():
             assert lhs["name"] == f
             assert lhs["size"] == len(v)
             assert lhs["type"] == "file"
-            # These are flags specific to Zip Files, there are many other flags, so a straight out comparison
-            # of the file info is more complicated
+
+            # There are many flags specific to Zip Files.
+            # These are two we can use to check we are getting some of them
             assert "CRC" in lhs
             assert "compress_size" in lhs
 

--- a/fsspec/implementations/tests/test_zip.py
+++ b/fsspec/implementations/tests/test_zip.py
@@ -87,7 +87,13 @@ def test_find():
         lhs = fsspec.filesystem("zip", fo=z)
 
         assert lhs.find("") == ["a", "b", "deeply/nested/path"]
-        assert lhs.find("", withdirs=True) == ["a", "b", "deeply/", "deeply/nested/", "deeply/nested/path"]
+        assert lhs.find("", withdirs=True) == [
+            "a",
+            "b",
+            "deeply/",
+            "deeply/nested/",
+            "deeply/nested/path",
+        ]
 
         assert lhs.find("deeply") == ["deeply/nested/path"]
         assert lhs.find("deeply/") == lhs.find("deeply")
@@ -136,7 +142,7 @@ def test_isdir_isfile(benchmark, scale):
     def make_nested_dir(i):
         x = f"{i}"
         table = x.maketrans("0123456789", "ABCDEFGHIJ")
-        return os.path.join(*x.translate(table))
+        return "/".join(x.translate(table))
 
     scaled_data = {f"{make_nested_dir(i)}/{i}": b"" for i in range(1, scale + 1)}
     with tempzip(scaled_data) as z:

--- a/fsspec/implementations/tests/test_zip.py
+++ b/fsspec/implementations/tests/test_zip.py
@@ -28,7 +28,7 @@ data = {"a": b"", "b": b"hello", "deeply/nested/path": b"stuff"}
 
 def test_empty():
     with tempzip() as z:
-        fs = fsspec.get_filesystem_class("zip")(fo=z)
+        fs = fsspec.filesystem("zip", fo=z)
         assert fs.find("") == []
         with pytest.raises(FileNotFoundError):
             fs.info("")
@@ -37,7 +37,7 @@ def test_empty():
 @pytest.mark.xfail(sys.version_info < (3, 6), reason="zip-info odd on py35")
 def test_mapping():
     with tempzip(data) as z:
-        fs = fsspec.get_filesystem_class("zip")(fo=z)
+        fs = fsspec.filesystem("zip", fo=z)
         m = fs.get_mapper("")
         assert list(m) == ["a", "b", "deeply/nested/path"]
         assert m["b"] == data["b"]
@@ -46,14 +46,14 @@ def test_mapping():
 @pytest.mark.xfail(sys.version_info < (3, 6), reason="zip not supported on py35")
 def test_pickle():
     with tempzip(data) as z:
-        fs = fsspec.get_filesystem_class("zip")(fo=z)
+        fs = fsspec.filesystem("zip", fo=z)
         fs2 = pickle.loads(pickle.dumps(fs))
         assert fs2.cat("b") == b"hello"
 
 
 def test_all_dirnames():
     with tempzip() as z:
-        fs = fsspec.get_filesystem_class("zip")(fo=z)
+        fs = fsspec.filesystem("zip", fo=z)
 
         # fx are files, dx are a directories
         assert fs._all_dirnames([]) == set()
@@ -67,7 +67,7 @@ def test_all_dirnames():
 
 def test_ls():
     with tempzip(data) as z:
-        lhs = fsspec.get_filesystem_class("zip")(fo=z)
+        lhs = fsspec.filesystem("zip", fo=z)
 
         assert lhs.ls("") == ["a", "b", "deeply/"]
         assert lhs.ls("/") == lhs.ls("")
@@ -81,8 +81,8 @@ def test_ls():
 
 def test_walk():
     with tempzip(data) as z:
-        fs_base = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="base")
-        fs_cache = fsspec.get_filesystem_class("zip")(fo=z)
+        fs_base = fsspec.filesystem("zip", fo=z, _info_implementation="base")
+        fs_cache = fsspec.filesystem("zip", fo=z)
 
         lhs = list(fs_base.walk(""))
         rhs = list(fs_cache.walk(""))
@@ -91,8 +91,8 @@ def test_walk():
 
 def test_info():
     with tempzip(data) as z:
-        fs_base = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="base")
-        fs_cache = fsspec.get_filesystem_class("zip")(fo=z)
+        fs_base = fsspec.filesystem("zip", fo=z, _info_implementation="base")
+        fs_cache = fsspec.filesystem("zip", fo=z)
 
         with pytest.raises(FileNotFoundError):
             fs_base.info("i-do-not-exist")
@@ -125,7 +125,7 @@ def test_isdir_isfile(benchmark, implementation, scale):
 
     scaled_data = {f"{make_nested_dir(i)}/{i}": b"" for i in range(1, scale + 1)}
     with tempzip(scaled_data) as z:
-        fs = fsspec.get_filesystem_class("zip")(
+        fs = fsspec.filesystem("zip",
             fo=z, _info_implementation=implementation
         )
 

--- a/fsspec/implementations/tests/test_zip.py
+++ b/fsspec/implementations/tests/test_zip.py
@@ -65,7 +65,7 @@ def test_all_dirnames():
         assert fs._all_dirnames(["d1/d1/d1/f1"]) == {"d1", "d1/d1", "d1/d1/d1"}
 
 
-def test_ls(monkeypatch):
+def test_ls():
     with tempzip(data) as z:
         lhs = fsspec.get_filesystem_class("zip")(fo=z)
 
@@ -115,7 +115,7 @@ def test_info():
 @pytest.mark.parametrize("implementation", ["base", "cache"])
 @pytest.mark.parametrize("scale", [128, 256, 512, 1024, 2048, 4096])
 def test_isdir_isfile(benchmark, implementation, scale):
-    if implementation == "base" and scale > 1_000:
+    if implementation == "base" and scale > 1000:
         pytest.skip("test takes too long...")
 
     def make_nested_dir(i):
@@ -123,9 +123,11 @@ def test_isdir_isfile(benchmark, implementation, scale):
         table = x.maketrans("0123456789", "ABCDEFGHIJ")
         return os.path.join(*x.translate(table))
 
-    scaled_data = {f"{make_nested_dir(i)}/{i}": b"" for i in range(1,scale+1)}
+    scaled_data = {f"{make_nested_dir(i)}/{i}": b"" for i in range(1, scale + 1)}
     with tempzip(scaled_data) as z:
-        fs = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation=implementation)
+        fs = fsspec.get_filesystem_class("zip")(
+            fo=z, _info_implementation=implementation
+        )
 
         lhs_dirs, lhs_files = fs._all_dirnames(scaled_data.keys()), scaled_data.keys()
 
@@ -133,6 +135,7 @@ def test_isdir_isfile(benchmark, implementation, scale):
         fs._get_dirs()
 
         entries = lhs_files | lhs_dirs
+
         @benchmark
         def split_into_dirs_files():
             rhs_dirs = {e for e in entries if fs.isdir(e)}

--- a/fsspec/implementations/tests/test_zip.py
+++ b/fsspec/implementations/tests/test_zip.py
@@ -26,16 +26,20 @@ def tempzip(data={}):
 data = {"a": b"", "b": b"hello", "deeply/nested/path": b"stuff"}
 
 
-def test_empty():
+@pytest.mark.parametrize("implementation", ["base", "cache"])
+def test_empty(implementation):
     with tempzip() as z:
-        fs = fsspec.get_filesystem_class("zip")(fo=z)
+        fs = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation=implementation)
         assert fs.find("") == []
+        with pytest.raises(FileNotFoundError):
+            fs.info("")
 
 
 @pytest.mark.xfail(sys.version_info < (3, 6), reason="zip-info odd on py35")
-def test_mapping():
+@pytest.mark.parametrize("implementation", ["base", "cache"])
+def test_mapping(implementation):
     with tempzip(data) as z:
-        fs = fsspec.get_filesystem_class("zip")(fo=z)
+        fs = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation=implementation)
         m = fs.get_mapper("")
         assert list(m) == ["a", "b", "deeply/nested/path"]
         assert m["b"] == data["b"]
@@ -51,43 +55,93 @@ def test_pickle():
 
 def test_all_dirnames():
     with tempzip() as z:
-        fs = fsspec.get_filesystem_class("zip")(fo=z)
+        fs = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="cache")
 
         # fx are files, dx are a directories
-        assert fs._all_dirnames(["f1"]) == {""}
-        assert fs._all_dirnames(["f1", "f2"]) == {""}
-        assert fs._all_dirnames(["f1", "f2", "d1/f1"]) == {"", "d1/"}
-        assert fs._all_dirnames(["f1", "f2", "d1/f1", "d1/f2"]) == {"", "d1/"}
-        assert fs._all_dirnames(["f1", "f2", "d1/f1", "d1/f2", "d2/f1"]) == {
-            "",
-            "d1/",
-            "d2/",
-        }
-        assert fs._all_dirnames(["d1/d1/d1/f1"]) == {"", "d1/", "d1/d1/", "d1/d1/d1/"}
+        assert fs._all_dirnames([]) == set()
+        assert fs._all_dirnames(["f1"]) == set()
+        assert fs._all_dirnames(["f1", "f2"]) == set()
+        assert fs._all_dirnames(["f1", "f2", "d1/f1"]) == {"d1"}
+        assert fs._all_dirnames(["f1", "d1/f1", "d1/f2"]) == {"d1"}
+        assert fs._all_dirnames(["f1", "d1/f1", "d2/f1"]) == {"d1", "d2"}
+        assert fs._all_dirnames(["d1/d1/d1/f1"]) == {"d1", "d1/d1", "d1/d1/d1"}
 
 
-@pytest.mark.parametrize("implementation", ["super", "cache"])
-def test_info(implementation):
+def test_ls(monkeypatch):
     with tempzip(data) as z:
-        fs = fsspec.get_filesystem_class("zip")(fo=z)
+        lhs = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="cache")
+
+        assert lhs.ls("") == ["a", "b", "deeply/"]
+        assert lhs.ls("/") == lhs.ls("")
+
+        assert lhs.ls("deeply") == ["deeply/nested/"]
+        assert lhs.ls("deeply/") == lhs.ls("deeply")
+
+        assert lhs.ls("deeply/nested") == ["deeply/nested/path"]
+        assert lhs.ls("deeply/nested/") == lhs.ls("deeply/nested")
+
+
+def test_walk():
+    with tempzip(data) as z:
+        fs_base = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="base")
+        fs_cache = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="cache")
+
+        lhs = list(fs_base.walk(""))
+        rhs = list(fs_cache.walk(""))
+        assert lhs == rhs
+
+
+def test_info():
+    with tempzip(data) as z:
+        fs_base = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="base")
+        fs_cache = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="cache")
 
         with pytest.raises(FileNotFoundError):
-            fs.info("i-do-not-exist")
+            fs_base.info("i-do-not-exist")
+        with pytest.raises(FileNotFoundError):
+            fs_cache.info("i-do-not-exist")
 
         # Iterate over all directories
-        for d in fs._all_dirnames(data.keys()):
-            d_info = fs.info(d, _info_implementation=implementation)
-            assert (d_info["type"], d_info["size"], d_info["name"]) == (
-                "directory",
-                0,
-                d,
-            )
+        for d in fs_cache._all_dirnames(data.keys()):
+            lhs = fs_base.info(d)
+            rhs = fs_cache.info(d)
+            assert lhs == rhs
 
         # Iterate over all files
         for f, v in data.items():
-            f_info = fs.info(f, _info_implementation=implementation)
-            assert (f_info["type"], f_info["size"], f_info["name"]) == (
-                "file",
-                len(v),
-                f,
-            )
+            lhs = fs_base.info(f)
+            rhs = fs_cache.info(f)
+            assert lhs == rhs
+
+
+@pytest.mark.parametrize("implementation", ["base", "cache"])
+@pytest.mark.parametrize("scale", [128, 256, 512, 1024, 2048, 4096])
+def test_isdir_isfile(benchmark, implementation, scale):
+    if implementation == "base" and scale > 1_000:
+        pytest.skip("test takes too long...")
+
+    def make_nested_dir(i):
+        x = f"{i}"
+        table = x.maketrans("0123456789", "ABCDEFGHIJ")
+        return os.path.join(*x.translate(table))
+
+    scaled_data = {f"{make_nested_dir(i)}/{i}": b"" for i in range(1,scale+1)}
+    with tempzip(scaled_data) as z:
+        fs = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation=implementation)
+
+        lhs_dirs, lhs_files = fs._all_dirnames(scaled_data.keys()), scaled_data.keys()
+
+        # Warm-up the Cache, this is done in both cases anyways...
+        fs._get_dirs()
+
+        entries = lhs_files | lhs_dirs
+        @benchmark
+        def split_into_dirs_files():
+            rhs_dirs = {e for e in entries if fs.isdir(e)}
+            rhs_files = {e for e in entries if fs.isfile(e)}
+            return rhs_dirs, rhs_files
+
+        rhs = split_into_dirs_files
+
+        assert lhs_dirs == rhs[0]
+        assert lhs_files == rhs[1]

--- a/fsspec/implementations/tests/test_zip.py
+++ b/fsspec/implementations/tests/test_zip.py
@@ -26,20 +26,18 @@ def tempzip(data={}):
 data = {"a": b"", "b": b"hello", "deeply/nested/path": b"stuff"}
 
 
-@pytest.mark.parametrize("implementation", ["base", "cache"])
-def test_empty(implementation):
+def test_empty():
     with tempzip() as z:
-        fs = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation=implementation)
+        fs = fsspec.get_filesystem_class("zip")(fo=z)
         assert fs.find("") == []
         with pytest.raises(FileNotFoundError):
             fs.info("")
 
 
 @pytest.mark.xfail(sys.version_info < (3, 6), reason="zip-info odd on py35")
-@pytest.mark.parametrize("implementation", ["base", "cache"])
-def test_mapping(implementation):
+def test_mapping():
     with tempzip(data) as z:
-        fs = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation=implementation)
+        fs = fsspec.get_filesystem_class("zip")(fo=z)
         m = fs.get_mapper("")
         assert list(m) == ["a", "b", "deeply/nested/path"]
         assert m["b"] == data["b"]
@@ -55,7 +53,7 @@ def test_pickle():
 
 def test_all_dirnames():
     with tempzip() as z:
-        fs = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="cache")
+        fs = fsspec.get_filesystem_class("zip")(fo=z)
 
         # fx are files, dx are a directories
         assert fs._all_dirnames([]) == set()
@@ -69,7 +67,7 @@ def test_all_dirnames():
 
 def test_ls(monkeypatch):
     with tempzip(data) as z:
-        lhs = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="cache")
+        lhs = fsspec.get_filesystem_class("zip")(fo=z)
 
         assert lhs.ls("") == ["a", "b", "deeply/"]
         assert lhs.ls("/") == lhs.ls("")
@@ -84,7 +82,7 @@ def test_ls(monkeypatch):
 def test_walk():
     with tempzip(data) as z:
         fs_base = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="base")
-        fs_cache = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="cache")
+        fs_cache = fsspec.get_filesystem_class("zip")(fo=z)
 
         lhs = list(fs_base.walk(""))
         rhs = list(fs_cache.walk(""))
@@ -94,7 +92,7 @@ def test_walk():
 def test_info():
     with tempzip(data) as z:
         fs_base = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="base")
-        fs_cache = fsspec.get_filesystem_class("zip")(fo=z, _info_implementation="cache")
+        fs_cache = fsspec.get_filesystem_class("zip")(fo=z)
 
         with pytest.raises(FileNotFoundError):
             fs_base.info("i-do-not-exist")

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -75,6 +75,10 @@ class ZipFileSystem(AbstractFileSystem):
                 )
                 self.dir_cache[f["name"]] = f
 
+    def info(self, path, **kwargs):
+        if kwargs.get("_info_implementation", "super") == "super":
+            return super().info(path, **kwargs)
+
     def ls(self, path, detail=False, **kwargs):
         self._get_dirs()
         paths = {}

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -152,5 +152,5 @@ class ZipFileSystem(AbstractFileSystem):
         if len(paths) == 0:
             return set()
 
-        dirnames = {os.path.dirname(path) for path in paths} - {f"{self.root_marker}"}
+        dirnames = {os.path.dirname(path) for path in paths} - {self.root_marker}
         return dirnames | self._all_dirnames(dirnames)

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division, absolute_import
 
-import os
 import zipfile
 from fsspec import AbstractFileSystem, open_files
 from fsspec.utils import tokenize, DEFAULT_BLOCK_SIZE
@@ -149,5 +148,5 @@ class ZipFileSystem(AbstractFileSystem):
         if len(paths) == 0:
             return set()
 
-        dirnames = {os.path.dirname(path) for path in paths} - {self.root_marker}
+        dirnames = {self._parent(path) for path in paths} - {self.root_marker}
         return dirnames | self._all_dirnames(dirnames)

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -56,9 +56,6 @@ class ZipFileSystem(AbstractFileSystem):
         self.block_size = block_size
         self.dir_cache = None
 
-        if kwargs.get("_info_implementation") == "base":
-            self.info = super().info
-
     @classmethod
     def _strip_protocol(cls, path):
         # zip file paths are always relative to the archive root

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ conda_deps=
     pyftpdlib
     cloudpickle
     pytest
+    pytest-benchmark
     pytest-cov
     fusepy==3.0.1
     msgpack-python<1.0.0


### PR DESCRIPTION
This new implementation gives us a O(1) lookup for any calls to zip.info(path).
The previous version was O(n), even after dir_cache was computed.

For example, one can now open a large zipfile stored in s3 very efficiently using the following
code:

```python
In [1]: import fsspec                                                                                                                                                                                              

In [2]: %%time  
   ...: of = fsspec.open_files("zip://**.jpg::blockcache://fast-ai-coco/unlabeled2017.zip::s3://", s3={"anon":True}) 
   ...: len(of) 
   ...:  
   ...:                                                                                                                                                                                                            
CPU times: user 2.65 s, sys: 117 ms, total: 2.77 s
Wall time: 4.69 s
Out[2]: 123403
```