### PR TITLE
Error reopening a blockcache

### DIFF
--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -77,8 +77,7 @@ def test_blockcache_workflow(ftp_writable, tmp_path, disable_fs_caching):
     with fs.open("/out", block_size=5) as f:
         assert f.read(5) == b"test\n"
         f.seek(30)
-        with pytest.raises(AttributeError):
-            assert f.read(5) == b"test\n"
+        assert f.read(5) == b"test\n"
 
 
 @pytest.mark.parametrize("impl", ["filecache", "blockcache"])

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -37,7 +37,15 @@ def test_idempotent():
     assert fs3.storage == fs.storage
 
 
-def test_blockcache_workflow(ftp_writable, tmp_path):
+@pytest.fixture()
+def disable_fs_caching():
+    # cheap version of monkeypatching, the built-in monkeypatch did not work
+    fsspec.spec.AbstractFileSystem.cachable = False
+    yield
+    fsspec.spec.AbstractFileSystem.cachable = True
+
+
+def test_blockcache_workflow(ftp_writable, tmp_path, disable_fs_caching):
     host, port, user, pw = ftp_writable
     fs = FTPFileSystem(host, port, user, pw)
     with fs.open("/out", "wb") as f:


### PR DESCRIPTION
I am having a little bit of a problem reopening a url that has a block cache in the middle.
Here is the exception I am getting:

It looks like a simple change from "add" to "append" fixes the problem, but I am not sure if it creates issues in other places.

The code that generate the exception is [here](https://github.com/sodre/intake-coco2017/blob/master/main.ipynb). To reproduce, run the notebook once, terminate the kernel, and start it back again. The exception will show up the second time.

<details>

```python-traceback
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
~/.conda/envs/intake-coco2017/lib/python3.8/site-packages/ipywidgets/widgets/interaction.py in update(self, *args)
    254                     value = widget.get_interact_value()
    255                     self.kwargs[widget._kwarg] = value
--> 256                 self.result = self.f(**self.kwargs)
    257                 show_inline_matplotlib_plots()
    258                 if self.auto_display and self.result is not None:

<ipython-input-3-6a5c22e1a584> in show(dataset, id)
     13 @interact(dataset=dataset_widget, id=partition_widget)
     14 def show(dataset, id):
---> 15     img = dataset.read_partition((id,))[0]
     16     io.imshow(img)

~/.conda/envs/intake-coco2017/lib/python3.8/site-packages/intake_xarray/base.py in read_partition(self, i)
     49         """
     50         import numpy as np
---> 51         self._load_metadata()
     52         if not isinstance(i, (tuple, list)):
     53             raise TypeError('For Xarray sources, must specify partition as '

~/.conda/envs/intake-coco2017/lib/python3.8/site-packages/intake/source/base.py in _load_metadata(self)
    124         """load metadata only if needed"""
    125         if self._schema is None:
--> 126             self._schema = self._get_schema()
    127             self.datashape = self._schema.datashape
    128             self.dtype = self._schema.dtype

~/.conda/envs/intake-coco2017/lib/python3.8/site-packages/intake_xarray/image.py in _get_schema(self)
    352 
    353         if self._ds is None:
--> 354             self._open_dataset()
    355 
    356             # convert to dataset for serialization

~/.conda/envs/intake-coco2017/lib/python3.8/site-packages/intake_xarray/image.py in _open_dataset(self)
    335         from dask.bytes import open_files
    336 
--> 337         files = open_files(self.urlpath, **self.storage_options)
    338         if len(files) == 0:
    339             raise Exception("No files found at {}".format(self.urlpath))

~/.conda/envs/intake-coco2017/lib/python3.8/site-packages/fsspec/core.py in open_files(urlpath, mode, compression, encoding, errors, name_function, num, protocol, newline, auto_mkdir, expand, **kwargs)
    223     List of ``OpenFile`` objects.
    224     """
--> 225     fs, fs_token, paths = get_fs_token_paths(
    226         urlpath,
    227         mode,

~/.conda/envs/intake-coco2017/lib/python3.8/site-packages/fsspec/core.py in get_fs_token_paths(urlpath, mode, num, name_function, storage_options, protocol, expand)
    539         path = cls._strip_protocol(urlpath)
    540         update_storage_options(options, storage_options)
--> 541         fs = cls(**options)
    542 
    543         if "w" in mode and expand:

~/.conda/envs/intake-coco2017/lib/python3.8/site-packages/fsspec/spec.py in __call__(cls, *args, **kwargs)
     52             return cls._cache[token]
     53         else:
---> 54             obj = super().__call__(*args, **kwargs)
     55             # Setting _fs_token here causes some static linters to complain.
     56             obj._fs_token_ = token

~/.conda/envs/intake-coco2017/lib/python3.8/site-packages/fsspec/implementations/zip.py in __init__(self, fo, mode, target_protocol, target_options, block_size, **kwargs)
     53             fo = files[0]
     54         self.fo = fo.__enter__()  # the whole instance is a context
---> 55         self.zip = zipfile.ZipFile(self.fo)
     56         self.block_size = block_size
     57         self.dir_cache = None

~/.conda/envs/intake-coco2017/lib/python3.8/zipfile.py in __init__(self, file, mode, compression, allowZip64, compresslevel, strict_timestamps)
   1266         try:
   1267             if mode == 'r':
-> 1268                 self._RealGetContents()
   1269             elif mode in ('w', 'x'):
   1270                 # set the modified flag so central directory gets written

~/.conda/envs/intake-coco2017/lib/python3.8/zipfile.py in _RealGetContents(self)
   1329         fp = self.fp
   1330         try:
-> 1331             endrec = _EndRecData(fp)
   1332         except OSError:
   1333             raise BadZipFile("File is not a zip file")

~/.conda/envs/intake-coco2017/lib/python3.8/zipfile.py in _EndRecData(fpin)
    271     except OSError:
    272         return None
--> 273     data = fpin.read()
    274     if (len(data) == sizeEndCentDir and
    275         data[0:4] == stringEndArchive and

~/.conda/envs/intake-coco2017/lib/python3.8/site-packages/fsspec/spec.py in read(self, length)
   1237             # don't even bother calling fetch
   1238             return b""
-> 1239         out = self.cache._fetch(self.loc, self.loc + length)
   1240         self.loc += len(out)
   1241         return out

~/.conda/envs/intake-coco2017/lib/python3.8/site-packages/fsspec/caching.py in _fetch(self, start, end)
     93             send = min(sstart + self.blocksize, self.size)
     94             self.cache[sstart:send] = self.fetcher(sstart, send)
---> 95             self.blocks.add(i)
     96 
     97         return self.cache[start:end]

AttributeError: 'list' object has no attribute 'add'
```
</details>