### PR TITLE
fixed typo "gui" => "gid"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,8 +91,6 @@ celerybeat-schedule
 .venv
 venv/
 ENV/
-.idea/
-.vscode/
 
 # Spyder project settings
 .spyderproject
@@ -106,3 +104,12 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# jetbrains ide stuff
+*.iml
+.idea/
+
+# vscode ide stuff
+*.code-workspace
+.history
+.vscode

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -88,7 +88,7 @@ class SFTPFileSystem(AbstractFileSystem):
             "size": s.st_size,
             "type": t,
             "uid": s.st_uid,
-            "gui": s.st_gid,
+            "gid": s.st_gid,
             "time": s.st_atime,
             "mtime": s.st_mtime,
         }


### PR DESCRIPTION
While reviewing #340, I noticed the same typo there and in `fsspec/implementations/sftp.py`:

https://github.com/intake/filesystem_spec/blob/f29eb56d0b8960cf2b4245afc8016c9aec3bb6bf/fsspec/implementations/sftp.py#L91

This is supposed to be `"gid": ...` right? I assume the type in #340 was copied from here