### PR TITLE
properly rewind MemoryFile (#349)

### DIFF
--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -114,10 +114,12 @@ class MemoryFileSystem(AbstractFileSystem):
         if mode in ["rb", "ab", "rb+"]:
             if path in self.store:
                 f = self.store[path]
-                if mode == "rb":
-                    f.seek(0)
-                else:
+                if mode == "ab":
+                    # position at the end of file
                     f.seek(0, 2)
+                else:
+                    # position at the beginning of file
+                    f.seek(0)
                 return f
             else:
                 raise FileNotFoundError(path)
@@ -177,7 +179,9 @@ class MemoryFile(BytesIO):
         return self
 
     def close(self):
+        position = self.tell()
         self.size = self.seek(0, 2)
+        self.seek(position)
 
     def discard(self):
         pass

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -58,3 +58,19 @@ def test_mv_recursive(m):
     m.mv("src", "dest", recursive=True)
     assert m.exists("dest/file.txt")
     assert not m.exists("src")
+
+
+def test_rewind(m):
+    # https://github.com/intake/filesystem_spec/issues/349
+    with m.open("src/file.txt", "w") as f:
+        f.write("content")
+    with m.open("src/file.txt") as f:
+        assert f.tell() == 0
+
+
+def test_no_rewind_append_mode(m):
+    # https://github.com/intake/filesystem_spec/issues/349
+    with m.open("src/file.txt", "w") as f:
+        f.write("content")
+    with m.open("src/file.txt", "a") as f:
+        assert f.tell() == 7

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -705,6 +705,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
     def tail(self, path, size=1024):
         """ Get the last ``size`` bytes from file """
         with self.open(path, "rb") as f:
+            print(f.size)
             f.seek(max(-size, -f.size), 2)
             return f.read()
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -705,7 +705,6 @@ class AbstractFileSystem(up, metaclass=_Cached):
     def tail(self, path, size=1024):
         """ Get the last ``size`` bytes from file """
         with self.open(path, "rb") as f:
-            print(f.size)
             f.seek(max(-size, -f.size), 2)
             return f.read()
 


### PR DESCRIPTION
Properly rewind `MemoryFile`

Context: https://github.com/intake/filesystem_spec/issues/349

The root problem was that the `seek(0, 2)` in `close()` was used to find the data length, but as a side-effect it was also changing the position of the cursor.

The solution is to still `seek(0, 2)` but reset the position to where it was before the seek.

Before this PR, the first test I added (`test_rewind`) was failing.

Simpler solutions, e.g. adding a `seek(0)` in `close`, make the second test I added (`test_no_rewind_append_mode`) fail.

---

Also, minor change in `_open`: replaced `if mode == "rb": f.seek(0, 2)` with `if mode == "ab": f.seek(0, 2)` because modes "rb" and "rb+" position the cursor at the beginning, while "ab" positions it at the end.