### PR TITLE
Fix race condition of lzma import when using threads

### DIFF
--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -73,10 +73,10 @@ register_compression("bz2", BZ2File, "bz2")
 register_compression("gzip", lambda f, **kwargs: GzipFile(fileobj=f, **kwargs), "gz")
 
 try:
-    import lzma
+    from lzma import LZMAFile
 
-    register_compression("lzma", lzma.LZMAFile, "xz")
-    register_compression("xz", lzma.LZMAFile, "xz", force=True)
+    register_compression("lzma", LZMAFile, "xz")
+    register_compression("xz", LZMAFile, "xz", force=True)
 except ImportError:
     pass
 


### PR DESCRIPTION
Fix a race condition of the import lzma that occurs when this is executed inside threads. Refer to similar issue in the python tar library [Python issue 39430: tarfile.open(mode="r") race condition when importing lzma](https://bugs.python.org/issue39430).

This fixes #353.