### PR TITLE
#355 typo fixed

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1275,7 +1275,7 @@ class AbstractBufferedFile(io.IOBase):
             This is the last block, so should complete file, if
             self.autocommit is True.
         """
-        # may not yet have been initialized, may neet to call _initialize_upload
+        # may not yet have been initialized, may need to call _initialize_upload
 
     def _initiate_upload(self):
         """ Create remote file/upload """


### PR DESCRIPTION
Fix typo `neet` to `need` in `spec.py` Line 1278.