### PR TITLE
Context for multiple files

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -36,6 +36,7 @@ Base Classes
    fsspec.FSMap
    fsspec.asyn.AsyncFileSystem
    fsspec.core.OpenFile
+   fsspec.core.OpenFiles
    fsspec.core.BaseCache
    fsspec.core.get_fs_token_paths
    fsspec.dircache.DirCache
@@ -58,6 +59,8 @@ Base Classes
 
 .. autoclass:: fsspec.core.OpenFile
    :members:
+
+.. autoclass:: fsspec.core.OpenFiles
 
 .. autoclass:: fsspec.core.BaseCache
    :members:

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -148,6 +148,18 @@ class OpenFile(object):
         _close(self.fobjects, self.mode)
 
 
+class OpenFiles(list):
+
+    def __enter__(self):
+        return [s.__enter__() for s in self]
+
+    def __exit__(self, *args):
+        [s.__exit__(*args) for s in self]
+
+    def __repr__(self):
+        return "List of %s open files" % len(self)
+
+
 def _close(fobjects, mode):
     for f in reversed(fobjects):
         if "r" not in mode and not f.closed:
@@ -234,7 +246,7 @@ def open_files(
     if "r" not in mode and auto_mkdir:
         parents = {fs._parent(path) for path in paths}
         [fs.makedirs(parent, exist_ok=True) for parent in parents]
-    return [
+    return OpenFiles([
         OpenFile(
             fs,
             path,
@@ -245,7 +257,7 @@ def open_files(
             newline=newline,
         )
         for path in paths
-    ]
+    ])
 
 
 def _un_chain(path, kwargs):

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -149,7 +149,6 @@ class OpenFile(object):
 
 
 class OpenFiles(list):
-
     def __enter__(self):
         return [s.__enter__() for s in self]
 
@@ -157,7 +156,7 @@ class OpenFiles(list):
         [s.__exit__(*args) for s in self]
 
     def __repr__(self):
-        return "List of %s open files" % len(self)
+        return "<List of %s open files>" % len(self)
 
 
 def _close(fobjects, mode):
@@ -246,18 +245,20 @@ def open_files(
     if "r" not in mode and auto_mkdir:
         parents = {fs._parent(path) for path in paths}
         [fs.makedirs(parent, exist_ok=True) for parent in parents]
-    return OpenFiles([
-        OpenFile(
-            fs,
-            path,
-            mode=mode,
-            compression=compression,
-            encoding=encoding,
-            errors=errors,
-            newline=newline,
-        )
-        for path in paths
-    ])
+    return OpenFiles(
+        [
+            OpenFile(
+                fs,
+                path,
+                mode=mode,
+                compression=compression,
+                encoding=encoding,
+                errors=errors,
+                newline=newline,
+            )
+            for path in paths
+        ]
+    )
 
 
 def _un_chain(path, kwargs):

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -149,6 +149,12 @@ class OpenFile(object):
 
 
 class OpenFiles(list):
+    """List of OpenFile instances
+
+    Can be used in a single context, which opens and closes all of the
+    contained files.
+    """
+
     def __enter__(self):
         return [s.__enter__() for s in self]
 
@@ -156,7 +162,7 @@ class OpenFiles(list):
         [s.__exit__(*args) for s in self]
 
     def __repr__(self):
-        return "<List of %s open files>" % len(self)
+        return "<List of %s OpenFile instances>" % len(self)
 
 
 def _close(fobjects, mode):
@@ -231,7 +237,8 @@ def open_files(
 
     Returns
     -------
-    List of ``OpenFile`` objects.
+    An ``OpenFiles`` instance, which is a ist of ``OpenFile`` objects that can
+    be used as a single context
     """
     fs, fs_token, paths = get_fs_token_paths(
         urlpath,

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -733,6 +733,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
                     continue
                 elif recursive:
                     out |= set(self.find(p, withdirs=True))
+                # TODO: the following is maybe only necessary if NOT recursive
                 out.add(p)
         if not out:
             raise FileNotFoundError(path)

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -3,7 +3,14 @@ import pickle
 import pytest
 import tempfile
 
-from fsspec.core import _expand_paths, OpenFile, open_local, get_compression, open_files
+from fsspec.core import (
+    _expand_paths,
+    OpenFile,
+    open_local,
+    get_compression,
+    open_files,
+    OpenFiles,
+)
 import fsspec
 
 
@@ -150,3 +157,17 @@ def test_url_kwargs_chain(ftp_writable):
         "rb",
     ) as f:
         assert f.read() == data
+
+
+def test_multi_context(tmpdir):
+    fns = [os.path.join(tmpdir, fn) for fn in ["a", "b"]]
+    files = open_files(fns, "wb")
+    assert isinstance(files, OpenFiles)
+    assert isinstance(files[0], OpenFile)
+    assert len(files) == 2
+    with files as of:
+        assert len(of) == 2
+        assert not of[0].closed
+        assert of[0].name.endswith("a")
+    assert of[0].closed
+    assert repr(files) == "<List of 2 OpenFile instances>"


### PR DESCRIPTION
See https://github.com/intake/filesystem_spec/issues/357

Should allow

```
with fsspec.open_files(...) as files:
```
where `files` is a list of open file-like instances.

@rabernat , what do you think?

Given the async work, this also raises questions around doing simultaneous things to the files, e.g., if they are cached, we could do the download in parallel.