### PR TITLE
HTTPFileSystem requires requests and aiohttp

### DIFF
--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -97,11 +97,11 @@ known_implementations = {
     },
     "http": {
         "class": "fsspec.implementations.http.HTTPFileSystem",
-        "err": 'HTTPFileSystem requires "requests" to be installed',
+        "err": 'HTTPFileSystem requires "requests" and "aiohttp" to be installed',
     },
     "https": {
         "class": "fsspec.implementations.http.HTTPFileSystem",
-        "err": 'HTTPFileSystem requires "requests" to be installed',
+        "err": 'HTTPFileSystem requires "requests" and "aiohttp" to be installed',
     },
     "zip": {"class": "fsspec.implementations.zip.ZipFileSystem"},
     "gcs": {


### PR DESCRIPTION
If `requests` but not `aiohttp` is installed the current error message is misleading since it only mentions requests.