### PR TITLE
Test against Python 3.8, drop 3.5 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ language: generic
 env:
   - TOXENV=py36
   - TOXENV=py37
+  - TOXENV=py38
   - TOXENV=coverage
   - TOXENV=lint
   - TOXENV=s3fs

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = {py35,py36,py37}
+envlist = {py36,py37,py38}
 
 [core]
 conda_channels=
@@ -82,7 +82,7 @@ basepython=python3.7
 skip_install=True
 conda_deps=
     {[dev]conda_deps}
-deps= 
+deps=
     {[dev]deps}
 commands_pre=
     pre-commit install --install-hooks


### PR DESCRIPTION
This aligns with the classifiers and discussion in #368.