### PR TITLE
add sign to base class

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1055,7 +1055,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
 
     def sign(self, path, expiration=100, **kwargs):
         """Create a signed URL representing the given path
-        
+
         Some implementations allow temporary URLs to be generated, as a
         way of delegating credentials.
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1053,6 +1053,9 @@ class AbstractFileSystem(up, metaclass=_Cached):
         """Alias of :ref:`FilesystemSpec.get`."""
         return self.get(rpath, lpath, recursive=recursive, **kwargs)
 
+    def sign(self, path, expiration=100):
+        raise NotImplementedError("Sign is not implemented for this filesystem")
+
 
 class AbstractBufferedFile(io.IOBase):
     """Convenient class to derive from to provide buffering

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1053,7 +1053,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
         """Alias of :ref:`FilesystemSpec.get`."""
         return self.get(rpath, lpath, recursive=recursive, **kwargs)
 
-    def sign(self, path, expiration=100):
+    def sign(self, path, expiration=100, **kwargs):
         raise NotImplementedError("Sign is not implemented for this filesystem")
 
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1054,14 +1054,17 @@ class AbstractFileSystem(up, metaclass=_Cached):
         return self.get(rpath, lpath, recursive=recursive, **kwargs)
 
     def sign(self, path, expiration=100, **kwargs):
-        """Return the signed URL representing this FileSystem
+        """Create a signed URL representing the given path
+        
+        Some implementations allow temporary URLs to be generated, as a
+        way of delegating credentials.
 
         Parameters
         ----------
         path : str
              The path on the filesystem
-        expiration : int or float
-            Number of seconds to enable the URL for
+        expiration : int
+            Number of seconds to enable the URL for (if supported)
 
         Returns
         -------

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1054,6 +1054,24 @@ class AbstractFileSystem(up, metaclass=_Cached):
         return self.get(rpath, lpath, recursive=recursive, **kwargs)
 
     def sign(self, path, expiration=100, **kwargs):
+        """Return the signed URL representing this FileSystem
+
+        Parameters
+        ----------
+        path : str
+             The path on the filesystem
+        expiration : int or float
+            Number of seconds to enable the URL for
+
+        Returns
+        -------
+        URL : str
+            The signed URL
+
+        Raises
+        ------
+        NotImplementedError : if method is not implemented for a fileystem
+        """
         raise NotImplementedError("Sign is not implemented for this filesystem")
 
 


### PR DESCRIPTION
This will enable downstream classes to specify how to sign urls, providing short term URLs for situations where the URL is needed but permissioning needs to be tightly controlled.