### PR TITLE
fix rst format

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -273,6 +273,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
         The specific keys, or perhaps a FileInfo class, or similar, is TBD,
         but must be consistent across implementations.
         Must include:
+
         - full path to the entry (without protocol)
         - size of the entry, in bytes. If the value cannot be determined, will
           be ``None``.


### PR DESCRIPTION
Refer to the error format:  https://filesystem-spec.readthedocs.io/en/latest/api.html :

![2020-08-25 11 24 23](https://user-images.githubusercontent.com/153287/91119399-a2a6af00-e6c5-11ea-8330-ce4eecc0ddfd.png)
