### PR TITLE
memory fs created time in detailed `ls`

### DIFF
--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 from io import BytesIO
+from datetime import datetime
 from fsspec import AbstractFileSystem
 import logging
 
@@ -23,6 +24,7 @@ class MemoryFileSystem(AbstractFileSystem):
                     "name": path,
                     "size": self.store[path].getbuffer().nbytes,
                     "type": "file",
+                    "created": self.store[path].created,
                 }
             ]
         else:
@@ -42,6 +44,7 @@ class MemoryFileSystem(AbstractFileSystem):
                         "name": has_slash + p,
                         "size": self.store[p2].getbuffer().nbytes,
                         "type": "file",
+                        "created": self.store[p2].created,
                     }
                 )
             elif (
@@ -174,6 +177,7 @@ class MemoryFile(BytesIO):
     def __init__(self, fs=None, path=None, data=None):
         self.fs = fs
         self.path = path
+        self.created = datetime.utcnow().timestamp()
         if data:
             self.write(data)
             self.size = len(data)


### PR DESCRIPTION
quick fix for a little issue I came across in my testing. I use the "created" time from the detailed `ls` response from the local and S3 filesystems in some logic. it'd be super useful if the memory repo's detailed `ls` also returned a "created" time for testing that part of the code with the memory repo