### PR TITLE
Cat error options

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -6,7 +6,7 @@ import os
 import sys
 import threading
 
-from .utils import other_paths
+from .utils import other_paths, is_exception
 from .spec import AbstractFileSystem
 
 # this global variable holds whether this thread is running async or not
@@ -72,7 +72,7 @@ def sync(loop, func, *args, callback_timeout=None, **kwargs):
 def maybe_sync(func, self, *args, **kwargs):
     """Make function call into coroutine or maybe run
 
-    If we are running async, returns the coroutine object so that it can be awaited;
+    If we are running async, run coroutine on current loop until done;
     otherwise runs it on the loop (if is a coroutine already) or directly. Will guess
     we are running async if either "self" has an attribute asynchronous which is True,
     or thread_state does (this gets set in ``sync()`` itself, to avoid nesting loops).
@@ -189,7 +189,7 @@ class AsyncFileSystem(AbstractFileSystem):
 
     def rm(self, path, recursive=False, **kwargs):
         path = self.expand_path(path, recursive=recursive)
-        sync(self.loop, self._rm, path, **kwargs)
+        maybe_sync(self._rm, self, path, **kwargs)
 
     async def _copy(self, paths, path2, **kwargs):
         await asyncio.gather(
@@ -199,7 +199,7 @@ class AsyncFileSystem(AbstractFileSystem):
     def copy(self, path1, path2, recursive=False, **kwargs):
         paths = self.expand_path(path1, recursive=recursive)
         path2 = other_paths(paths, path2)
-        sync(self.loop, self._copy, paths, path2)
+        maybe_sync(self._copy, self, paths, path2)
 
     async def _pipe(self, path, value=None, **kwargs):
         if isinstance(path, str):
@@ -213,18 +213,27 @@ class AsyncFileSystem(AbstractFileSystem):
             *[
                 asyncio.ensure_future(self._cat_file(path, **kwargs), loop=self.loop)
                 for path in paths
-            ]
+            ],
+            return_exceptions=True
         )
 
-    def cat(self, path, recursive=False, **kwargs):
+    def cat(self, path, recursive=False, on_error="raise", **kwargs):
         paths = self.expand_path(path, recursive=recursive)
-        out = sync(self.loop, self._cat, paths, **kwargs)
+        out = maybe_sync(self._cat, self, paths, **kwargs)
+        if on_error == "raise":
+            ex = next(filter(is_exception, out), False)
+            if ex:
+                raise ex
         if (
             len(paths) > 1
             or isinstance(path, list)
             or paths[0] != self._strip_protocol(path)
         ):
-            return {k: v for k, v in zip(paths, out)}
+            return {
+                k: v
+                for k, v in zip(paths, out)
+                if on_error != "omit" or not is_exception(v)
+            }
         else:
             return out[0]
 
@@ -245,9 +254,11 @@ class AsyncFileSystem(AbstractFileSystem):
         fs = LocalFileSystem()
         lpaths = fs.expand_path(lpath, recursive=recursive)
         rpaths = other_paths(lpaths, rpath)
-        sync(self.loop, self._put, lpaths, rpaths, **kwargs)
+        maybe_sync(self._put, self, lpaths, rpaths, **kwargs)
 
     async def _get(self, rpaths, lpaths, **kwargs):
+        dirs = [os.path.dirname(lp) for lp in lpaths]
+        [os.makedirs(d, exist_ok=True) for d in dirs]
         return await asyncio.gather(
             *[
                 self._get_file(rpath, lpath, **kwargs)

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -200,7 +200,7 @@ class AsyncFileSystem(AbstractFileSystem):
         paths = self.expand_path(path1, recursive=recursive)
         path2 = other_paths(paths, path2)
         maybe_sync(self._copy, self, paths, path2)
-\
+
     async def _pipe(self, path, value=None, **kwargs):
         if isinstance(path, str):
             path = {path: value}

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -240,9 +240,12 @@ def test_async_this_thread(server):
         loop = asyncio.get_event_loop()
         fs = fsspec.filesystem("http", asynchronous=True, loop=loop)
 
+        # fails because client creation has not yet been awaited
+        assert isinstance(
+            (await fs._cat([server + "/index/realfile"]))[0], RuntimeError
+        )
         with pytest.raises(RuntimeError):
-            # fails because client creation has not yet been awaited
-            await fs._cat([server + "/index/realfile"])
+            fs.cat([server + "/index/realfile"])
 
         await fs.set_session()  # creates client
 

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -75,7 +75,7 @@ class FSMap(MutableMapping):
         on_error : "raise", "omit", "return"
             If raise, an underlying exception will be raised (converted to KeyError
             if the type is in self.missing_exceptions); if omit, keys with exception
-            will simply not be included in hte output; if "return", all keys are
+            will simply not be included in the output; if "return", all keys are
             included in the output, but the value will be bytes or an exception
             instance.
 
@@ -94,9 +94,9 @@ class FSMap(MutableMapping):
             for k, v in out.items()
         }
         return {
-            key: v
-            for key, (k, v) in zip(keys, out.items())
-            if on_error == "return" or not isinstance(v, BaseException)
+            key: out[k2]
+            for key, k2 in zip(keys, keys2)
+            if on_error == "return" or not isinstance(out[k2], BaseException)
         }
 
     def setitems(self, values_dict):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -625,6 +625,11 @@ class AbstractFileSystem(up, metaclass=_Cached):
         or the path has been otherwise expanded
 
         on_error : "raise", "omit", "return"
+            If raise, an underlying exception will be raised (converted to KeyError
+            if the type is in self.missing_exceptions); if omit, keys with exception
+            will simply not be included in the output; if "return", all keys are
+            included in the output, but the value will be bytes or an exception
+            instance.
         """
         paths = self.expand_path(path, recursive=recursive)
         if (

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -359,3 +359,7 @@ def other_paths(paths, path2, is_dir=None):
     else:
         assert len(paths) == len(path2)
     return path2
+
+
+def is_exception(obj):
+    return isinstance(obj, BaseException)


### PR DESCRIPTION
To allow async usage in zarr, provide options of what happens on missing items when doing `cat` (or mapping `getitems`).