### PR TITLE
Stop inheriting from pyarrow.filesystem for pyarrow>=2.0

### DIFF
--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -6,6 +6,7 @@ import os.path
 import pickle
 import sys
 from contextlib import contextmanager
+from distutils.version import LooseVersion
 import posixpath
 import tempfile
 
@@ -325,8 +326,11 @@ def test_get_pyarrow_filesystem():
     pa = pytest.importorskip("pyarrow")
 
     fs = LocalFileSystem()
-    assert isinstance(fs, pa.filesystem.FileSystem)
-    assert fs._get_pyarrow_filesystem() is fs
+    if LooseVersion(pa.__version__) < LooseVersion("2.0"):
+        assert isinstance(fs, pa.filesystem.FileSystem)
+        assert fs._get_pyarrow_filesystem() is fs
+    else:
+        assert not isinstance(fs, pa.filesystem.FileSystem)
 
     class UnknownFileSystem(object):
         pass

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -66,15 +66,15 @@ class _Cached(type):
 
 
 try:  # optionally derive from pyarrow's FileSystem, if available
-    # TODO: it should be possible to disable this
     import pyarrow as pa
-
+except ImportError:
+    up = object
+else:
+    # only derive from the legacy pyarrow's FileSystem for older pyarrow versions
     if LooseVersion(pa.__version__) < LooseVersion("2.0"):
         up = pa.filesystem.DaskFileSystem
     else:
         up = object
-except ImportError:
-    up = object
 
 
 class AbstractFileSystem(up, metaclass=_Cached):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -2,6 +2,7 @@ import io
 import logging
 import os
 import warnings
+from distutils.version import LooseVersion
 from hashlib import sha256
 from glob import has_magic
 
@@ -68,7 +69,10 @@ try:  # optionally derive from pyarrow's FileSystem, if available
     # TODO: it should be possible to disable this
     import pyarrow as pa
 
-    up = pa.filesystem.DaskFileSystem
+    if LooseVersion(pa.__version__) < LooseVersion("2.0"):
+        up = pa.filesystem.DaskFileSystem
+    else:
+        up = object
 except ImportError:
     up = object
 
@@ -1085,6 +1089,13 @@ class AbstractFileSystem(up, metaclass=_Cached):
         NotImplementedError : if method is not implemented for a fileystem
         """
         raise NotImplementedError("Sign is not implemented for this filesystem")
+
+    def _isfilestore(self):
+        # Originally inherited from pyarrow DaskFileSystem. Keeping this
+        # here for backwards compatibility as long as pyarrow uses its
+        # legacy ffspec-compatible filesystems and thus accepts fsspec
+        # filesystems as well
+        return False
 
 
 class AbstractBufferedFile(io.IOBase):


### PR DESCRIPTION
See discussion in https://github.com/intake/filesystem_spec/issues/295

Starting with pyarrow 2.0, the legacy `pyarrow.filesystem` FileSystems will be officially deprecated. As preparation, I think that fsspec can also stop inheriting from it. 

Almost all methods on the base class from pyarrow are actually overridden / implemented in fsspec, so no longer inheriting from it shouldn't have a big impact, except for `isinstance` checks. I am doing some changes in pyarrow to allow fsspec filesystems instead of doing a strict `isinstance`.