### PR TITLE
handle multibyte dtypes

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1364,7 +1364,7 @@ class AbstractBufferedFile(io.IOBase):
 
         https://docs.python.org/3/library/io.html#io.RawIOBase.readinto
         """
-        data = self.read(len(b))
+        data = self.read(len(bytearray(b)))
         memoryview(b).cast("B")[: len(data)] = data
         return len(data)
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1364,8 +1364,9 @@ class AbstractBufferedFile(io.IOBase):
 
         https://docs.python.org/3/library/io.html#io.RawIOBase.readinto
         """
-        data = self.read(len(bytearray(b)))
-        memoryview(b).cast("B")[: len(data)] = data
+        out = memoryview(b).cast("B")
+        data = self.read(out.nbytes)
+        out[: len(data)] = data
         return len(data)
 
     def readuntil(self, char=b"\n", blocks=None):

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -1,11 +1,15 @@
 import pickle
 import json
 
+import os
 import pytest
 from fsspec.spec import AbstractFileSystem, AbstractBufferedFile
+from fsspec.implementations.ftp import FTPFile, FTPFileSystem
+from fsspec.implementations.local import LocalFileSystem
 import fsspec
 
 import numpy as np
+from pathlib import Path
 
 
 class DummyTestFS(AbstractFileSystem):
@@ -231,6 +235,95 @@ def test_readinto_with_numpy(tmpdir, dt):
 
     arr2 = np.empty_like(arr)
     with fsspec.open(store_path, "rb") as f:
+        f.readinto(arr2)
+
+    assert np.array_equal(arr, arr2)
+
+
+class BrokenFTPFile(FTPFile):
+    """
+    This class is purely for test_readinto_with_multibyte below. I suspect a far more
+    elegant solution is possible for someone more familiar with fsspec but it enables
+    the test below which was the goal.
+    """
+    def __init__(self, fs, path, mode):
+        super(BrokenFTPFile, self).__init__(fs=fs, path=path, mode=mode)
+
+    def _connect(self):
+        pass
+
+    def _open(self):
+        return self.fs._open(self.path)
+
+    def _fetch_range(self, start, end):
+        # probably only used by cached FS
+        if "r" not in self.mode:
+            raise ValueError
+        self.f = self._open()
+        self.f.seek(start)
+        return self.f.read(end - start)
+
+    def info(self, path, **kwargs):
+        out = os.stat(path, follow_symlinks=False)
+        dest = False
+        if os.path.islink(path):
+            t = "link"
+            dest = os.readlink(path)
+        elif os.path.isdir(path):
+            t = "directory"
+        elif os.path.isfile(path):
+            t = "file"
+        else:
+            t = "other"
+        result = {"name": path, "size": out.st_size, "type": t, "created": out.st_ctime}
+        for field in ["mode", "uid", "gid", "mtime"]:
+            result[field] = getattr(out, "st_" + field)
+        if dest:
+            result["destination"] = dest
+            try:
+                out2 = os.stat(path, follow_symlinks=True)
+                result["size"] = out2.st_size
+            except IOError:
+                result["size"] = 0
+        return result
+
+    def cp_file(self, path1, path2, **kwargs):
+        pass
+
+    def created(self, path):
+        pass
+
+    def modified(self, path):
+        pass
+
+    def sign(self, path, expiration=100, **kwargs):
+        pass
+
+
+@pytest.mark.parametrize(
+    "dt",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.float32,
+        np.float64,
+    ],
+)
+def test_readinto_with_multibyte(tmpdir, dt):
+    store_path = str(tmpdir / "test_arr.npy")
+    arr = np.arange(10, dtype=dt)
+    arr.tofile(store_path)
+
+    arr2 = np.empty_like(arr)
+
+    fs = LocalFileSystem()  # BrokenFTPFileSystem()
+    with BrokenFTPFile(fs, path=store_path, mode="rb") as f:
         f.readinto(arr2)
 
     assert np.array_equal(arr, arr2)

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -4,12 +4,11 @@ import json
 import os
 import pytest
 from fsspec.spec import AbstractFileSystem, AbstractBufferedFile
-from fsspec.implementations.ftp import FTPFile, FTPFileSystem
+from fsspec.implementations.ftp import FTPFile
 from fsspec.implementations.local import LocalFileSystem
 import fsspec
 
 import numpy as np
-from pathlib import Path
 
 
 class DummyTestFS(AbstractFileSystem):


### PR DESCRIPTION
First off thank you so much for fsspec and all the work it entailed! 
We think we have a fix for a small bug.
We ran into the following problem.
When we execute this script: 
``` python
from s3fs import S3FileSystem
from tifffile import imread
fs = S3FileSystem(anon=True)
with fs.open("s3://aics-modeling-packages-test-resources/aicsimageio/test_resources/resources/s_1_t_1_c_1_z_1.tiff") as open_resource:
    print(type(open_resource))
    print(imread(open_resource).shape)
```
we encounter the following exception:
```
<class 's3fs.core.S3File'>
Traceback (most recent call last):
  File "/Users/jamies/Library/Application Support/JetBrains/PyCharm2020.1/scratches/scratch_13.py", line 14, in <module>
    print(imread(open_resource).shape)
  File "/Users/jamies/Sandbox/Scratch/Jackson/tifffile/tifffile/tifffile.py", line 721, in imread
    return tif.asarray(**kwargs)
  File "/Users/jamies/Sandbox/Scratch/Jackson/tifffile/tifffile/tifffile.py", line 2804, in asarray
    result = self.filehandle.read_array(
  File "/Users/jamies/Sandbox/Scratch/Jackson/tifffile/tifffile/tifffile.py", line 7498, in read_array
    raise ValueError(f'failed to read {size} bytes')
ValueError: failed to read 308750 bytes
Process finished with exit code 1
```
When we traced it back it seems to be the read() in readinto() doesn't seem to allow for array types of more than 1 byte so this fixes that by simply casting to a bytearray prior to getting length.