### PR TITLE
Guard against instance reuse when forking

### DIFF
--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -265,7 +265,7 @@ def _inner_pass(fs, q, fn):
 
 
 @pytest.mark.parametrize("method", ["spawn", "forkserver", "fork"])
-def test_processes(server, method):
+def test_processes(server, method, monkeypatch):
     import multiprocessing as mp
 
     if win and method != "spawn":
@@ -276,7 +276,7 @@ def test_processes(server, method):
 
     q = ctx.Queue()
     if os.environ.get("TRAVIS", ""):
-        os.chdir("/")
+        monkeypatch.chdir(os.path.dirname(sys.executable))
     p = ctx.Process(target=_inner_pass, args=(fs, q, fn))
     p.start()
     assert q.get() == fs.cat(fn)

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -276,7 +276,7 @@ def test_processes(server, method):
 
     q = ctx.Queue()
     if os.environ.get("TRAVIS", ""):
-        os.chdir("")
+        os.chdir("/")
     p = ctx.Process(target=_inner_pass, args=(fs, q, fn))
     p.start()
     assert q.get() == fs.cat(fn)

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -12,7 +12,7 @@ port = 9898
 data = b"\n".join([b"some test data"] * 1000)
 realfile = "http://localhost:%i/index/realfile" % port
 index = b'<a href="%s">Link</a>' % realfile.encode()
-win = os.name == 'nt'
+win = os.name == "nt"
 
 
 class HTTPTestHandler(BaseHTTPRequestHandler):
@@ -267,6 +267,7 @@ def _inner_pass(fs, q, fn):
 @pytest.mark.parametrize("method", ["spawn", "forkserver", "fork"])
 def test_processes(server, method):
     import multiprocessing as mp
+
     if win and method != "spawn":
         pytest.skip("Windows can only spawn")
     ctx = mp.get_context(method)

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -275,6 +275,8 @@ def test_processes(server, method):
     fs = fsspec.filesystem("http")
 
     q = ctx.Queue()
+    if os.environ.get("TRAVIS", ""):
+        os.chdir("")
     p = ctx.Process(target=_inner_pass, args=(fs, q, fn))
     p.start()
     assert q.get() == fs.cat(fn)

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -264,7 +264,9 @@ def _inner_pass(fs, q, fn):
     q.put(fs.cat(fn))
 
 
-@pytest.mark.skipif(os.environ.get("TRAVIS", ""), reason="Travis is weird in many ways")
+@pytest.mark.skipif(
+    bool(os.environ.get("TRAVIS", "")), reason="Travis is weird in many ways"
+)
 @pytest.mark.parametrize("method", ["spawn", "forkserver", "fork"])
 def test_processes(server, method):
     import multiprocessing as mp

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -12,6 +12,7 @@ port = 9898
 data = b"\n".join([b"some test data"] * 1000)
 realfile = "http://localhost:%i/index/realfile" % port
 index = b'<a href="%s">Link</a>' % realfile.encode()
+win = os.name == 'nt'
 
 
 class HTTPTestHandler(BaseHTTPRequestHandler):
@@ -254,3 +255,26 @@ def test_async_this_thread(server):
         assert out == [data]
 
     asyncio.run(_())
+
+
+def _inner_pass(fs, q, fn):
+    # pass the s3 instance, but don't use it; in new process, the instance
+    # cache should be skipped to make a new instance
+    fs = fsspec.filesystem("http")
+    q.put(fs.cat(fn))
+
+
+@pytest.mark.parametrize("method", ["spawn", "forkserver", "fork"])
+def test_processes(server, method):
+    import multiprocessing as mp
+    if win and method != "spawn":
+        pytest.skip("Windows can only spawn")
+    ctx = mp.get_context(method)
+    fn = server + "/index/realfile"
+    fs = fsspec.filesystem("http")
+
+    q = ctx.Queue()
+    p = ctx.Process(target=_inner_pass, args=(fs, q, fn))
+    p.start()
+    assert q.get() == fs.cat(fn)
+    p.join()

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -265,7 +265,7 @@ def _inner_pass(fs, q, fn):
 
 
 @pytest.mark.parametrize("method", ["spawn", "forkserver", "fork"])
-def test_processes(server, method, monkeypatch):
+def test_processes(server, method):
     import multiprocessing as mp
 
     if win and method != "spawn":
@@ -276,7 +276,7 @@ def test_processes(server, method, monkeypatch):
 
     q = ctx.Queue()
     if os.environ.get("TRAVIS", ""):
-        monkeypatch.chdir(os.path.dirname(sys.executable))
+        os.chdir(os.path.dirname(sys.executable))
     p = ctx.Process(target=_inner_pass, args=(fs, q, fn))
     p.start()
     assert q.get() == fs.cat(fn)

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -264,6 +264,7 @@ def _inner_pass(fs, q, fn):
     q.put(fs.cat(fn))
 
 
+@pytest.mark.skipif(os.environ.get("TRAVIS", ""), reason="Travis is weird in many ways")
 @pytest.mark.parametrize("method", ["spawn", "forkserver", "fork"])
 def test_processes(server, method):
     import multiprocessing as mp
@@ -275,8 +276,6 @@ def test_processes(server, method):
     fs = fsspec.filesystem("http")
 
     q = ctx.Queue()
-    if os.environ.get("TRAVIS", ""):
-        os.chdir(os.path.dirname(sys.executable))
     p = ctx.Process(target=_inner_pass, args=(fs, q, fn))
     p.start()
     assert q.get() == fs.cat(fn)

--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,7 @@ deps=
     {[core]deps}
 commands =
     py.test -v -r s
+passenv = TRAVIS
 
 [testenv:coverage]
 description=Run test suite with coverage enabled.
@@ -61,6 +62,7 @@ deps=
     {[core]deps}
 commands =
     py.test --cov=fsspec -v -r s
+passenv = TRAVIS
 
 [testenv:dev]
 description=Setup conda dev env under '.tox/dev'.


### PR DESCRIPTION
Required since instance (e.g., aiohttp) may hold open connections,
which will deadlock after fork.

Fixes https://github.com/dask/s3fs/issues/369