### PR TITLE
Config system

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+Version 0.8.4
+-------------
+
+Features:
+
+- function ``can_be_local`` to see whether URL is compatible with ``open_local``
+- concurrent cat with filecaches, if backend supports it
+
+Fixes:
+
+- dircache expiry after transaction
+- blockcache garbage collection
+- close for HDFS
+- windows tests
+- glob depth with "**"
+
 Version 0.8.3
 -------------
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Version
+-------
+
+Features:
+
+- config system
+
 Version 0.8.4
 -------------
 
@@ -8,6 +15,7 @@ Features:
 
 - function ``can_be_local`` to see whether URL is compatible with ``open_local``
 - concurrent cat with filecaches, if backend supports it
+- jupyter FS
 
 Fixes:
 
@@ -28,7 +36,7 @@ Features:
 
 Fixes:
 
-- duplicate directories could appear in MemoreFileSystem
+- duplicate directories could appear in MemoryFileSystem
 - Added support for hat dollar lbrace rbrace regex character escapes in glob
 - Fix blockcache (was doing unnecessary work)
 - handle multibyte dtypes in readinto

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -342,6 +342,53 @@ The interface provides the following outputs:
 - ``.fs``: the current filesystem instance
 - ``.open_file()``: produces an ``OpenFile`` instance for the current selection
 
+Configuration
+-------------
+
+You can set default keyword arguments to pass to any fsspec backend by editing
+config files, providing environment variables, or editing the contents of
+the dictionary ``fsspec.config.conf``.
+
+Files are stored in the directory pointed to by ``FSSPEC_CONFIG_DIR``,
+``"~/.config/fsspec/`` by default. All *.ini and *.json files will be
+loaded and parsed from their respective formats and fed into the config dict
+at import time. For example, if there is a file "~/.config/fsspec/conf.json"
+containing
+
+.. code-block:: json
+
+   {"file": {"auto_mkdir": true}}
+
+then any instance of the file system whose protocol is "file" (i.e.,
+``LocalFileSystem``) with be passed the kwargs ``auto_mkdir=True``
+**unless** the user supplies the kwarg themselves.
+
+For instance:
+
+.. code-block:: python
+
+    import fsspec
+    fs = fsspec.filesystem("file")
+    assert fs.auto_mkdir == True
+    fs = fsspec.filesystem("file", auto_mkdir=False)
+    assert fs.auto_mkdir == False
+
+Obviously, you should only define default values that are appropriate for
+a given file system implementation. INI files only support string values.
+
+Alternatively, you can provide overrides with environment variables of
+the style "FSSPEC_{protocol}_{kwargname}=value".
+
+Configuration is determined in the following order, with later items winning:
+
+- the contents of ini files, and json files in the config directory, sorted
+  alphabetically
+- environment variables
+- the contents of ``fsspec.config.conf``, which can be edited at runtime
+- kwargs explicitly passed, whether with ``fsspec.open``, ``fsspec.filesystem``
+  or directly instantiating the implementation class.
+
+
 Async
 =====
 

--- a/fsspec/config.py
+++ b/fsspec/config.py
@@ -81,7 +81,7 @@ def apply_config(cls, kwargs, conf_dict=conf):
     -------
     dict : the modified set of kwargs
     """
-    protos = cls.protocol if isinstance(cls.protocol, tuple) else [cls.protocol]
+    protos = cls.protocol if isinstance(cls.protocol, (tuple, list)) else [cls.protocol]
     kw = {}
     for proto in protos:
         # default kwargs from the current state of the config

--- a/fsspec/config.py
+++ b/fsspec/config.py
@@ -8,21 +8,24 @@ default_conf_dir = os.path.join(os.path.expanduser("~"), ".fsspec")
 conf_dir = os.environ.get("FSSPEC_CONFIG_DIR", default_conf_dir)
 
 
-def set_conf_env(conf_dict):
+def set_conf_env(conf_dict, envdict=os.environ):
     """Set config values from environment variables
 
     Looks for variable of the form ``FSSPEC_<protocol>_<kwarg>``.
-    There is no attempt to convert strings.
+    There is no attempt to convert strings, but the kwarg keys will
+    be lower-cased.
 
     Parameters
     ----------
     conf_dict : dict(str, dict)
         This dict will be mutated
+    envdict : dict-like(str, str)
+        Source for the values - usually the real environment
     """
-    for key in os.environ:
+    for key in envdict:
         if key.startswith("FSSPEC"):
             _, proto, kwarg = key.split("_", 2)
-            conf_dict.setdefault(proto.lower(), {})[kwarg.lower()] = os.environ[key]
+            conf_dict.setdefault(proto.lower(), {})[kwarg.lower()] = envdict[key]
 
 
 def set_conf_files(cdir, conf_dict):

--- a/fsspec/config.py
+++ b/fsspec/config.py
@@ -1,7 +1,11 @@
+import configparser
+import json
 import os
 
 
 conf = {}
+default_conf_dir = os.path.join(os.path.expanduser("~"), ".fsspec")
+conf_dir = os.environ.get("FSSPEC_CONFIG_DIR", default_conf_dir)
 
 
 def set_conf_env():
@@ -11,4 +15,31 @@ def set_conf_env():
             conf.setdefault(proto.lower(), {})[kwarg.lower()] = os.environ[key]
 
 
+def set_conf_files(cdir):
+    allfiles = os.listdir(cdir)
+    for fn in allfiles:
+        if fn.endswith(".ini"):
+            ini = configparser.ConfigParser()
+            ini.read(os.path.join(cdir, fn))
+            for key in ini:
+                conf.setdefault(key, {}).update(dict(ini[key]))
+        if fn.endswith(".json"):
+            js = json.load(open(os.path.join(cdir, fn)))
+            for key in js:
+                conf.setdefault(key, {}).update(dict(js[key]))
+
+
+def apply_config(cls, kwargs):
+    protos = cls.protocol if isinstance(cls.protocol, tuple) else cls.protocol
+    for proto in protos:
+        # set default kwargs that have NOT been specified
+        # using the current state of the config
+        if proto in conf:
+            kw = conf[proto].copy()
+            kw.update(**kwargs)
+            kwargs = kw
+    return kwargs
+
+
+set_conf_files(conf_dir)
 set_conf_env()

--- a/fsspec/config.py
+++ b/fsspec/config.py
@@ -1,0 +1,14 @@
+import os
+
+
+conf = {}
+
+
+def set_conf_env():
+    for key in os.environ:
+        if key.startswith("FSSPEC"):
+            _, proto, kwarg = key.split("_", 2)
+            conf.setdefault(proto.lower(), {})[kwarg.lower()] = os.environ[key]
+
+
+set_conf_env()

--- a/fsspec/config.py
+++ b/fsspec/config.py
@@ -45,6 +45,8 @@ def set_conf_files(cdir, conf_dict):
     conf_dict : dict(str, dict)
         This dict will be mutated
     """
+    if not os.path.isdir(cdir):
+        return
     allfiles = os.listdir(cdir)
     for fn in allfiles:
         if fn.endswith(".ini"):

--- a/fsspec/config.py
+++ b/fsspec/config.py
@@ -4,7 +4,7 @@ import os
 
 
 conf = {}
-default_conf_dir = os.path.join(os.path.expanduser("~"), ".fsspec")
+default_conf_dir = os.path.join(os.path.expanduser("~"), ".config/fsspec")
 conf_dir = os.environ.get("FSSPEC_CONFIG_DIR", default_conf_dir)
 
 

--- a/fsspec/config.py
+++ b/fsspec/config.py
@@ -8,38 +8,81 @@ default_conf_dir = os.path.join(os.path.expanduser("~"), ".fsspec")
 conf_dir = os.environ.get("FSSPEC_CONFIG_DIR", default_conf_dir)
 
 
-def set_conf_env():
+def set_conf_env(conf_dict):
+    """Set config values from environment variables
+
+    Looks for variable of the form ``FSSPEC_<protocol>_<kwarg>``.
+    There is no attempt to convert strings.
+
+    Parameters
+    ----------
+    conf_dict : dict(str, dict)
+        This dict will be mutated
+    """
     for key in os.environ:
         if key.startswith("FSSPEC"):
             _, proto, kwarg = key.split("_", 2)
-            conf.setdefault(proto.lower(), {})[kwarg.lower()] = os.environ[key]
+            conf_dict.setdefault(proto.lower(), {})[kwarg.lower()] = os.environ[key]
 
 
-def set_conf_files(cdir):
+def set_conf_files(cdir, conf_dict):
+    """Set config values from files
+
+    Scans for INI and JSON files in the given dictionary, and uses their
+    contents to set the config. In case of repeated values, later values
+    win.
+
+    In the case of INI files, all values are strings, and these will not
+    be converted.
+
+    Parameters
+    ----------
+    cdir : str
+        Directory to search
+    conf_dict : dict(str, dict)
+        This dict will be mutated
+    """
     allfiles = os.listdir(cdir)
     for fn in allfiles:
         if fn.endswith(".ini"):
             ini = configparser.ConfigParser()
             ini.read(os.path.join(cdir, fn))
             for key in ini:
-                conf.setdefault(key, {}).update(dict(ini[key]))
+                conf_dict.setdefault(key, {}).update(dict(ini[key]))
         if fn.endswith(".json"):
             js = json.load(open(os.path.join(cdir, fn)))
             for key in js:
-                conf.setdefault(key, {}).update(dict(js[key]))
+                conf_dict.setdefault(key, {}).update(dict(js[key]))
 
 
-def apply_config(cls, kwargs):
+def apply_config(cls, kwargs, conf_dict=conf):
+    """Supply default values for kwargs when instantiating class
+
+    Augments the passed kwargs, by finding entries in the config dict
+    which match the classes ``.protocol`` attribute (one or more str)
+
+    Parameters
+    ----------
+    cls : file system implementation
+    kwargs : dict
+    conf_dict : dict of dict
+        Typically this is the global configuration
+
+    Returns
+    -------
+    dict : the modified set of kwargs
+    """
     protos = cls.protocol if isinstance(cls.protocol, tuple) else cls.protocol
+    kw = {}
     for proto in protos:
-        # set default kwargs that have NOT been specified
-        # using the current state of the config
-        if proto in conf:
-            kw = conf[proto].copy()
-            kw.update(**kwargs)
-            kwargs = kw
+        # default kwargs from the current state of the config
+        if proto in conf_dict:
+            kw.update(conf_dict[proto])
+    # explicit kwargs always win
+    kw.update(**kwargs)
+    kwargs = kw
     return kwargs
 
 
-set_conf_files(conf_dir)
-set_conf_env()
+set_conf_files(conf_dir, conf)
+set_conf_env(conf)

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -10,6 +10,7 @@ from glob import has_magic
 from .dircache import DirCache
 from .transaction import Transaction
 from .utils import read_block, tokenize, stringify_path, other_paths
+from .config import conf
 
 logger = logging.getLogger("fsspec")
 
@@ -44,6 +45,7 @@ class _Cached(type):
         cls._pid = os.getpid()
 
     def __call__(cls, *args, **kwargs):
+        proto = cls.protocol if isinstance(cls.protocol, str) else cls.protocol[0]
         extra_tokens = tuple(
             getattr(cls, attr, None) for attr in cls._extra_tokenize_attributes
         )
@@ -55,6 +57,8 @@ class _Cached(type):
         if not skip and cls.cachable and token in cls._cache:
             return cls._cache[token]
         else:
+            if proto in conf:
+                kwargs = dict(**conf[proto], **kwargs)
             obj = super().__call__(*args, **kwargs)
             # Setting _fs_token here causes some static linters to complain.
             obj._fs_token_ = token

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -10,7 +10,7 @@ from glob import has_magic
 from .dircache import DirCache
 from .transaction import Transaction
 from .utils import read_block, tokenize, stringify_path, other_paths
-from .config import conf
+from .config import apply_config
 
 logger = logging.getLogger("fsspec")
 
@@ -45,7 +45,7 @@ class _Cached(type):
         cls._pid = os.getpid()
 
     def __call__(cls, *args, **kwargs):
-        proto = cls.protocol if isinstance(cls.protocol, str) else cls.protocol[0]
+        kwargs = apply_config(cls, kwargs)
         extra_tokens = tuple(
             getattr(cls, attr, None) for attr in cls._extra_tokenize_attributes
         )
@@ -57,10 +57,6 @@ class _Cached(type):
         if not skip and cls.cachable and token in cls._cache:
             return cls._cache[token]
         else:
-            if proto in conf:
-                kw = conf[proto].copy()
-                kw.update(**kwargs)
-                kwargs = kw
             obj = super().__call__(*args, **kwargs)
             # Setting _fs_token here causes some static linters to complain.
             obj._fs_token_ = token

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -58,7 +58,9 @@ class _Cached(type):
             return cls._cache[token]
         else:
             if proto in conf:
-                kwargs = dict(**conf[proto], **kwargs)
+                kw = conf[proto].copy()
+                kw.update(**kwargs)
+                kwargs = kw
             obj = super().__call__(*args, **kwargs)
             # Setting _fs_token here causes some static linters to complain.
             obj._fs_token_ = token

--- a/fsspec/tests/test_config.py
+++ b/fsspec/tests/test_config.py
@@ -53,7 +53,7 @@ def test_from_file_json(clean_conf, tmpdir):
     with open(file1, "w") as f:
         f.write(
             """{"proto":
-{"key": "value", 
+{"key": "value",
 "other_key": "othervalue",
 "overwritten": false}}
         """

--- a/fsspec/tests/test_config.py
+++ b/fsspec/tests/test_config.py
@@ -1,0 +1,76 @@
+import os
+import pytest
+import fsspec
+from fsspec.config import conf, set_conf_env, set_conf_files
+
+
+@pytest.fixture
+def clean_conf():
+    """Tests should start and end with clean config dict"""
+    conf.clear()
+    yield
+    conf.clear()
+
+
+def test_from_env(clean_conf):
+    env = {'FSSPEC_PROTO_KEY': "value",
+           'FSSPEC_PROTO_LONG_KEY': "othervalue",
+           'FSSPEC_MALFORMED': "novalue"}
+    cd = {}
+    set_conf_env(conf_dict=cd, envdict=env)
+    assert cd == {"proto": {
+        "key": "value",
+        "long_key": "othervalue"
+    }}
+
+
+def test_from_file_ini(clean_conf, tmpdir):
+    file1 = os.path.join(tmpdir, "1.ini")
+    file2 = os.path.join(tmpdir, "2.ini")
+    with open(file1, 'w') as f:
+        f.write("""[proto]
+key=value
+other_key:othervalue
+overwritten=dont_see
+        """)
+    with open(file2, 'w') as f:
+        f.write("""[proto]
+overwritten=see
+        """)
+    cd = {}
+    set_conf_files(tmpdir, cd)
+    assert cd == {"proto": {
+        "key": "value",
+        "other_key": "othervalue",
+        "overwritten": "see"
+    }}
+
+
+def test_from_file_json(clean_conf, tmpdir):
+    file1 = os.path.join(tmpdir, "1.json")
+    file2 = os.path.join(tmpdir, "2.json")
+    with open(file1, 'w') as f:
+        f.write("""{"proto":
+{"key": "value", 
+"other_key": "othervalue",
+"overwritten": false}}
+        """)
+    with open(file2, 'w') as f:
+        f.write("""{"proto":
+{"overwritten": true}}
+        """)
+    cd = {}
+    set_conf_files(tmpdir, cd)
+    assert cd == {"proto": {
+        "key": "value",
+        "other_key": "othervalue",
+        "overwritten": True
+    }}
+
+
+def test_apply(clean_conf):
+    conf['file'] = {'auto_mkdir': "test"}
+    fs = fsspec.filesystem("file")
+    assert fs.auto_mkdir == "test"
+    fs = fsspec.filesystem("file", auto_mkdir=True)
+    assert fs.auto_mkdir is True

--- a/fsspec/tests/test_config.py
+++ b/fsspec/tests/test_config.py
@@ -13,63 +13,66 @@ def clean_conf():
 
 
 def test_from_env(clean_conf):
-    env = {'FSSPEC_PROTO_KEY': "value",
-           'FSSPEC_PROTO_LONG_KEY': "othervalue",
-           'FSSPEC_MALFORMED': "novalue"}
+    env = {
+        "FSSPEC_PROTO_KEY": "value",
+        "FSSPEC_PROTO_LONG_KEY": "othervalue",
+        "FSSPEC_MALFORMED": "novalue",
+    }
     cd = {}
     set_conf_env(conf_dict=cd, envdict=env)
-    assert cd == {"proto": {
-        "key": "value",
-        "long_key": "othervalue"
-    }}
+    assert cd == {"proto": {"key": "value", "long_key": "othervalue"}}
 
 
 def test_from_file_ini(clean_conf, tmpdir):
     file1 = os.path.join(tmpdir, "1.ini")
     file2 = os.path.join(tmpdir, "2.ini")
-    with open(file1, 'w') as f:
-        f.write("""[proto]
+    with open(file1, "w") as f:
+        f.write(
+            """[proto]
 key=value
 other_key:othervalue
 overwritten=dont_see
-        """)
-    with open(file2, 'w') as f:
-        f.write("""[proto]
+        """
+        )
+    with open(file2, "w") as f:
+        f.write(
+            """[proto]
 overwritten=see
-        """)
+        """
+        )
     cd = {}
     set_conf_files(tmpdir, cd)
-    assert cd == {"proto": {
-        "key": "value",
-        "other_key": "othervalue",
-        "overwritten": "see"
-    }}
+    assert cd == {
+        "proto": {"key": "value", "other_key": "othervalue", "overwritten": "see"}
+    }
 
 
 def test_from_file_json(clean_conf, tmpdir):
     file1 = os.path.join(tmpdir, "1.json")
     file2 = os.path.join(tmpdir, "2.json")
-    with open(file1, 'w') as f:
-        f.write("""{"proto":
+    with open(file1, "w") as f:
+        f.write(
+            """{"proto":
 {"key": "value", 
 "other_key": "othervalue",
 "overwritten": false}}
-        """)
-    with open(file2, 'w') as f:
-        f.write("""{"proto":
+        """
+        )
+    with open(file2, "w") as f:
+        f.write(
+            """{"proto":
 {"overwritten": true}}
-        """)
+        """
+        )
     cd = {}
     set_conf_files(tmpdir, cd)
-    assert cd == {"proto": {
-        "key": "value",
-        "other_key": "othervalue",
-        "overwritten": True
-    }}
+    assert cd == {
+        "proto": {"key": "value", "other_key": "othervalue", "overwritten": True}
+    }
 
 
 def test_apply(clean_conf):
-    conf['file'] = {'auto_mkdir': "test"}
+    conf["file"] = {"auto_mkdir": "test"}
     fs = fsspec.filesystem("file")
     assert fs.auto_mkdir == "test"
     fs = fsspec.filesystem("file", auto_mkdir=True)


### PR DESCRIPTION
Allows configuring of any kwarg parameter for backends.
Precedence is (latest wins):
- .ini and .json files in the config directory, in listdir order
- environment variables of the form `FSSPEC_<protocol>_<kwarg>` (will be lower-cased, so cannot use for kwargs with upper case characters in the name)
- any dynamic changes to the `fsspec.config.conf` dictionary
- parameters passed at instantiation time

JSON file can look like:
```json
{"gcs":
  {"requester_pays": true}
}
```
INI file:
```ini
[gsc]
requester_pays=true
```
(note that JSON files will have correct types, but ini files only support strings)
