### PR TITLE
Fix MemoryFileSystem recursive rm bug

### DIFF
--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -164,6 +164,17 @@ class MemoryFileSystem(AbstractFileSystem):
         else:
             raise FileNotFoundError
 
+    def rm(self, path, recursive=False, maxdepth=None):
+        paths = self.expand_path(path, recursive=recursive, maxdepth=maxdepth)
+        for p in reversed(paths):
+            # If the expanded path doesn't exist, it is only because the expanded
+            # path was a directory that does not exist in self.pseudo_dirs. This
+            # is possible if you directly create files without making the
+            # directories first.
+            if not self.exists(p):
+                continue
+            self.rm_file(p)
+
     def size(self, path):
         """Size in bytes of the file at path"""
         if path not in self.store:

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -63,6 +63,17 @@ def test_mv_recursive(m):
     assert not m.exists("src")
 
 
+def test_rm_no_psuedo_dir(m):
+    m.touch("/dir1/dir2/file")
+    m.rm("/dir1", recursive=True)
+    assert not m.exists("/dir1/dir2/file")
+    assert not m.exists("/dir1/dir2")
+    assert not m.exists("/dir1")
+
+    with pytest.raises(FileNotFoundError):
+        m.rm("/dir1", recursive=True)
+
+
 def test_rewind(m):
     # https://github.com/intake/filesystem_spec/issues/349
     with m.open("src/file.txt", "w") as f:


### PR DESCRIPTION
This change fixes an existing bug that throws an error when removing a
directory recursively which contains non-psuedo sub-dirs.

As MemoryFileSystem allows you to create files without creating the
parent directories first, those parent directories are not added to
`pseudo_dirs`. We should ignore deleting such directories in recursive
remove operation since once the underneath files are deleted, the
directory would be automatically deleted.