### PR TITLE
Fix and test expand_path recursive

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -802,8 +802,11 @@ class AbstractFileSystem(up, metaclass=_Cached):
                         # We add all the globbed results under the assumption
                         # .glob() expands paths (only files are documented but
                         # in test they do) and files paths are OK with this function
-                        out |= set(self.expand_path(list(bit), recursive=recursive,
-                                                    maxdepth=maxdepth))
+                        out |= set(
+                            self.expand_path(
+                                list(bit), recursive=recursive, maxdepth=maxdepth
+                            )
+                        )
                     continue
                 elif recursive:
                     # TODO: maxdepth is not used and probably should

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -68,9 +68,13 @@ class DummyTestFS(AbstractFileSystem):
     @classmethod
     def get_test_paths(cls, start_with=""):
         """Helper to return directory and file paths with no details"""
-        all = [file["name"] for file in cls._fs_contents if
-               file["name"].startswith(start_with)]
+        all = [
+            file["name"]
+            for file in cls._fs_contents
+            if file["name"].startswith(start_with)
+        ]
         return all
+
 
 @pytest.mark.parametrize(
     "test_path, expected",
@@ -129,36 +133,48 @@ def test_glob(test_path, expected):
     for name, info in res.items():
         assert info == test_fs[name]
 
-@pytest.mark.parametrize(["test_paths", "expected"],
-                         [(("top_level/second_level", "top_level/sec*", "top_level/*"),
-                           ["top_level/second_level",
-                            "top_level/second_level/date=2019-10-01",
-                            "top_level/second_level/date=2019-10-01/a.parquet",
-                            "top_level/second_level/date=2019-10-01/b.parquet",
-                            "top_level/second_level/date=2019-10-02",
-                            "top_level/second_level/date=2019-10-02/a.parquet",
-                            "top_level/second_level/date=2019-10-04",
-                            "top_level/second_level/date=2019-10-04/a.parquet",
-                            ]),
-                          # Note: fails because 'glob_test' files are missing (intentionally?) from ls
-                          # Todo: figure out what ls ought to return
-                          # ((DummyTestFS.root_marker, ), DummyTestFS.get_test_paths() + [DummyTestFS.root_marker])
-                          ])
+
+@pytest.mark.parametrize(
+    ["test_paths", "expected"],
+    [
+        (
+            ("top_level/second_level", "top_level/sec*", "top_level/*"),
+            [
+                "top_level/second_level",
+                "top_level/second_level/date=2019-10-01",
+                "top_level/second_level/date=2019-10-01/a.parquet",
+                "top_level/second_level/date=2019-10-01/b.parquet",
+                "top_level/second_level/date=2019-10-02",
+                "top_level/second_level/date=2019-10-02/a.parquet",
+                "top_level/second_level/date=2019-10-04",
+                "top_level/second_level/date=2019-10-04/a.parquet",
+            ],
+        ),
+        (("misc/foo.txt", "misc/*.txt"), ["misc/foo.txt"]),
+        # Note: fails because 'glob_test' paths are missing (intentionally?) from ls,
+        #  remove comments and add id to fail it
+        # Todo: figure out what test_fs.ls("") ought to return
+        # ((DummyTestFS.root_marker,), DummyTestFS.get_test_paths() + [DummyTestFS.root_marker]),
+    ],
+    ids=["all_second_level", "single_file"],
+)
 def test_expand_path_recursive(test_paths, expected):
-    """Test a number of querys and then their combination that all should yield
+    """Test a number of paths and then their combination which should all yield
     the same set of expanded paths"""
     test_fs = DummyTestFS()
 
     # test single query
     for test_path in test_paths:
         paths = test_fs.expand_path(test_path, recursive=True)
-        assert sorted(paths) == sorted(expected), \
-            f"path(s) '{test_path}' didn't expand as expected"
+        assert sorted(paths) == sorted(
+            expected
+        ), f"path(s) '{test_path}' didn't expand as expected"
 
     # test with all queries
     paths = test_fs.expand_path(list(test_paths), recursive=True)
-    assert sorted(paths) == sorted(expected), \
-        f"all test paths didn't expand as expected"
+    assert sorted(paths) == sorted(
+        expected
+    ), f"all test paths didn't expand as expected"
 
 
 def test_find_details():

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -65,6 +65,11 @@ class DummyTestFS(AbstractFileSystem):
 
         return list(sorted(files))
 
+    def get_all_file_paths(self):
+        """Helper that returns all expected file paths"""
+        all = [file["name"] for file in self._fs_contents if
+               file["type"] == "file"]
+        return all
 
 @pytest.mark.parametrize(
     "test_path, expected",
@@ -122,6 +127,15 @@ def test_glob(test_path, expected):
     assert sorted(res) == expected  # FIXME: py35 back-compat
     for name, info in res.items():
         assert info == test_fs[name]
+
+
+def test_expand_path_recursive():
+    test_fs = DummyTestFS()
+    paths = test_fs.expand_path(test_fs.root_marker, recursive=True)
+    # fails because also directories include root_marker are returned in
+    # contrast to docstring where it says files
+    assert set(paths) == set(test_fs.get_all_file_paths()), \
+        "root marker didn't expand to all file paths"
 
 
 def test_find_details():

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -129,8 +129,8 @@ def test_glob(test_path, expected):
     for name, info in res.items():
         assert info == test_fs[name]
 
-@pytest.mark.parametrize(["test_path", "expected"],
-                         [("top_level/second_level",
+@pytest.mark.parametrize(["test_paths", "expected"],
+                         [(("top_level/second_level", "top_level/sec*", "top_level/*"),
                            ["top_level/second_level",
                             "top_level/second_level/date=2019-10-01",
                             "top_level/second_level/date=2019-10-01/a.parquet",
@@ -140,14 +140,25 @@ def test_glob(test_path, expected):
                             "top_level/second_level/date=2019-10-04",
                             "top_level/second_level/date=2019-10-04/a.parquet",
                             ]),
-                          # Note: fails because 'glob_test' files are missing (intentionally?) in ls
-                          # (DummyTestFS.root_marker, DummyTestFS.get_test_paths() + [DummyTestFS.root_marker])
+                          # Note: fails because 'glob_test' files are missing (intentionally?) from ls
+                          # Todo: figure out what ls ought to return
+                          # ((DummyTestFS.root_marker, ), DummyTestFS.get_test_paths() + [DummyTestFS.root_marker])
                           ])
-def test_expand_path_recursive(test_path, expected):
+def test_expand_path_recursive(test_paths, expected):
+    """Test a number of querys and then their combination that all should yield
+    the same set of expanded paths"""
     test_fs = DummyTestFS()
-    paths = test_fs.expand_path(test_path, recursive=True)
+
+    # test single query
+    for test_path in test_paths:
+        paths = test_fs.expand_path(test_path, recursive=True)
+        assert sorted(paths) == sorted(expected), \
+            f"path(s) '{test_path}' didn't expand as expected"
+
+    # test with all queries
+    paths = test_fs.expand_path(list(test_paths), recursive=True)
     assert sorted(paths) == sorted(expected), \
-        f"path(s) '{test_path}' didn't expand as expected"
+        f"all test paths didn't expand as expected"
 
 
 def test_find_details():


### PR DESCRIPTION
Should eventually fix #456 
Before that, needs clarification what `expand_path` is supposed to return: directories (including root), files, both? See failing test.