### PR TITLE
add kwargs to exists

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -552,10 +552,10 @@ class AbstractFileSystem(up, metaclass=_Cached):
         else:
             return list(out)
 
-    def exists(self, path):
+    def exists(self, path, **kwargs):
         """Is there a file at the given path"""
         try:
-            self.info(path)
+            self.info(path, kwargs)
             return True
         except:  # noqa: E722
             # any exception allowed bar FileNotFoundError?

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -555,7 +555,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
     def exists(self, path, **kwargs):
         """Is there a file at the given path"""
         try:
-            self.info(path, kwargs)
+            self.info(path, **kwargs)
             return True
         except:  # noqa: E722
             # any exception allowed bar FileNotFoundError?


### PR DESCRIPTION
add kwargs to `exists(...)` function and passes them to call of `info(...)`

Why is this meaningful?

When calling exists function in s3fs implementation the result is cached. So a second call will return `True` again, even if the file was deleted between the calls. The cache can be bypassed by providing parameter `refresh=True` to the call of `info(...)`.

This change solves this issue by simply forwarding all `kwargs` to `info(...)`