### PR TITLE
Add option to ignore file not found errors in copy

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -87,8 +87,10 @@ class LocalFileSystem(AbstractFileSystem):
             self.makedirs(self._parent(path2), exist_ok=True)
         if self.isfile(path1):
             shutil.copyfile(path1, path2)
-        else:
+        elif self.isdir(path1):
             self.mkdirs(path2, exist_ok=True)
+        else:
+            raise FileNotFoundError
 
     def get_file(self, path1, path2, **kwargs):
         return self.cp_file(path1, path2, **kwargs)

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -12,6 +12,7 @@ import tempfile
 
 import pytest
 import fsspec
+from unittest.mock import patch
 from fsspec.core import open_files, get_fs_token_paths, OpenFile
 from fsspec.implementations.local import LocalFileSystem, make_path_posix
 from fsspec import compression
@@ -550,3 +551,44 @@ def test_mv_recursive(tmpdir):
     assert localfs.isdir(src) is False
     assert localfs.isdir(dest)
     assert localfs.info(os.path.join(dest, "afile"))
+
+
+def test_copy_errors(tmpdir):
+    localfs = fsspec.filesystem("file")
+
+    dest1 = os.path.join(str(tmpdir), "dest1")
+    dest2 = os.path.join(str(tmpdir), "dest2")
+
+    src = os.path.join(str(tmpdir), "src")
+    file1 = os.path.join(src, "afile1")
+    file2 = os.path.join(src, "afile2")
+    dne = os.path.join(str(tmpdir), "src", "notafile")
+
+    localfs.mkdir(src)
+    localfs.mkdir(dest1)
+    localfs.mkdir(dest2)
+    localfs.touch(file1)
+    localfs.touch(file2)
+
+    # Non recursive should raise an error unless we specify ignore
+    with pytest.raises(FileNotFoundError):
+        localfs.copy([file1, file2, dne], dest1)
+
+    localfs.copy([file1, file2, dne], dest1, on_error="ignore")
+    assert sorted(localfs.ls(dest1)) == [
+        os.path.join(dest1, "afile1"),
+        os.path.join(dest1, "afile2"),
+    ]
+
+    # Recursive should raise an error only if we specify raise
+    # the patch simulates the filesystem finding a file that does not exist in the directory
+    current_files = localfs.expand_path(src, recursive=True)
+    with patch.object(localfs, "expand_path", return_value=current_files + [dne]):
+        with pytest.raises(FileNotFoundError):
+            localfs.copy(src, dest2, recursive=True, on_error="raise")
+
+        localfs.copy(src, dest2, recursive=True)
+        assert sorted(localfs.ls(dest2)) == [
+            os.path.join(dest2, "afile1"),
+            os.path.join(dest2, "afile2"),
+        ]

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -777,12 +777,27 @@ class AbstractFileSystem(up, metaclass=_Cached):
     def cp_file(self, path1, path2, **kwargs):
         raise NotImplementedError
 
-    def copy(self, path1, path2, recursive=False, **kwargs):
-        """ Copy within two locations in the filesystem"""
+    def copy(self, path1, path2, recursive=False, on_error=None, **kwargs):
+        """ Copy within two locations in the filesystem
+
+        on_error : "raise", "ignore"
+            If raise, any not-found exceptions will be raised; if ignore any
+            not-found exceptions will cause the path to be skipped; defaults to
+            raise unless recursive is true, where the default is ignore
+        """
+        if on_error is None and recursive:
+            on_error = "ignore"
+        elif on_error is None:
+            on_error = "raise"
+
         paths = self.expand_path(path1, recursive=recursive)
         path2 = other_paths(paths, path2)
         for p1, p2 in zip(paths, path2):
-            self.cp_file(p1, p2, **kwargs)
+            try:
+                self.cp_file(p1, p2, **kwargs)
+            except FileNotFoundError:
+                if on_error == "raise":
+                    raise
 
     def expand_path(self, path, recursive=False, maxdepth=None):
         """Turn one or more globs or directories into a list of all matching files"""

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -778,7 +778,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
         raise NotImplementedError
 
     def copy(self, path1, path2, recursive=False, on_error=None, **kwargs):
-        """ Copy within two locations in the filesystem
+        """Copy within two locations in the filesystem
 
         on_error : "raise", "ignore"
             If raise, any not-found exceptions will be raised; if ignore any


### PR DESCRIPTION
Ignores by default in recursive copy but is not on by default for
non-recursive.

Fix first half of dask/gcsfs#307