### PR TITLE
Fix TypeError raised by FileSystem.get()

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -811,7 +811,8 @@ class AbstractFileSystem(up, metaclass=_Cached):
                     bit = set(self.glob(p))
                     out |= bit
                     if recursive:
-                        out += self.expand_path(p)
+                        rec = set(self.expand_path(p))
+                        out |= rec
                     continue
                 elif recursive:
                     rec = set(self.find(p, withdirs=True))


### PR DESCRIPTION
Reproduce

```python
import fsspec
fs = fsspec.filesystem("s3")
fs.get("s3://my_bucket/data.zarr/**", "data.zarr", recursive=True)
```

will cause 

```
  ...
    fs.get(from_path, to_path, recursive=recursive)
  File ".../lib/site-packages/fsspec/asyn.py", line 278, in get
    rpaths = self.expand_path(rpath, recursive=recursive)
  File ".../lib/site-packages/fsspec/spec.py", line 779, in expand_path
    out = self.expand_path([path], recursive, maxdepth)
  File ".../lib/site-packages/fsspec/spec.py", line 788, in expand_path
    out += self.expand_path(p)
TypeError: unsupported operand type(s) for +=: 'set' and 'list'
```