### PR TITLE
Don't import pyarrow just to check version

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -2,7 +2,6 @@ import io
 import logging
 import os
 import warnings
-from distutils.version import LooseVersion
 from errno import ESPIPE
 from hashlib import sha256
 from glob import has_magic
@@ -12,6 +11,7 @@ from .transaction import Transaction
 from .utils import (
     read_block,
     tokenize,
+    loose_version,
     stringify_path,
     other_paths,
     get_package_version_without_import,
@@ -79,7 +79,7 @@ class _Cached(type):
 
 
 pa_version = get_package_version_without_import("pyarrow")
-if LooseVersion(pa_version) < LooseVersion("2.0"):
+if pa_version and loose_version(pa_version) < loose_version("2.0"):
     import pyarrow as pa
 
     up = pa.filesystem.DaskFileSystem

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -4,6 +4,7 @@ import os
 import warnings
 from errno import ESPIPE
 from hashlib import sha256
+from distutils.version import LooseVersion
 from glob import has_magic
 
 from .dircache import DirCache
@@ -11,7 +12,6 @@ from .transaction import Transaction
 from .utils import (
     read_block,
     tokenize,
-    loose_version,
     stringify_path,
     other_paths,
     get_package_version_without_import,
@@ -79,7 +79,7 @@ class _Cached(type):
 
 
 pa_version = get_package_version_without_import("pyarrow")
-if pa_version and loose_version(pa_version) < loose_version("2.0"):
+if pa_version and LooseVersion(pa_version) < LooseVersion("2.0"):
     import pyarrow as pa
 
     up = pa.filesystem.DaskFileSystem

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -3,6 +3,7 @@ import math
 import os
 import pathlib
 import re
+import sys
 from urllib.parse import urlsplit
 
 
@@ -383,10 +384,13 @@ def can_be_local(path):
         return False
 
 
-def setup_logger(logname, level="DEBUG"):
+def setup_logger(logname, level="DEBUG", clear=True):
+    """Add standard logging handler to logger of given name"""
     import logging
 
     logger = logging.getLogger(logname)
+    if clear:
+        logger.handlers.clear()
     handle = logging.StreamHandler()
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s " "- %(message)s"
@@ -395,3 +399,35 @@ def setup_logger(logname, level="DEBUG"):
     logger.addHandler(handle)
     logger.setLevel(level)
     return logger
+
+
+def get_package_version_without_import(name):
+    """For given package name, try to find the version without importing it
+
+    Import and package.__version__ is still the backup here, so an import
+    *might* happen.
+
+    Returns either the version string, or None if the package
+    or the version was not readily  found.
+    """
+    if name in sys.modules:
+        mod = sys.modules[name]
+        if hasattr(mod, "__version__"):
+            return mod.__version__
+    if sys.version_info >= (3, 8):
+        import importlib.metadata
+
+        return importlib.metadata.distribution(name).version
+    try:
+        import importlib_metadata
+
+        return importlib_metadata.distribution(name).version
+    except ImportError:
+        pass
+    try:
+        import importlib
+
+        mod = importlib.import_module(name)
+        return mod.__version__
+    except (ImportError, AttributeError):
+        return None

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -415,15 +415,19 @@ def get_package_version_without_import(name):
         if hasattr(mod, "__version__"):
             return mod.__version__
     if sys.version_info >= (3, 8):
-        import importlib.metadata
+        try:
+            import importlib.metadata
 
-        return importlib.metadata.distribution(name).version
-    try:
-        import importlib_metadata
+            return importlib.metadata.distribution(name).version
+        except ImportError:
+            pass
+    else:
+        try:
+            import importlib_metadata
 
-        return importlib_metadata.distribution(name).version
-    except ImportError:
-        pass
+            return importlib_metadata.distribution(name).version
+        except ImportError:
+            pass
     try:
         import importlib
 


### PR DESCRIPTION
We would rather not import pyarrow, since from v2.0.0, we don't use it anyway.

Ref #411 

cc @jorisvandenbossche - this is the chain of version checks that we talked about in your PR.

```
[ ] %time import fsspec
93 ms (this branch)
183 ms (master)
```