### PR TITLE
Fix appending of random directory within find() method

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Dev
+-------------
+
+Fixes:
+
+- random appending of a directory within the filesystems ``find()`` method
+
 Version 0.8.5
 -------------
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -427,7 +427,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
         path = self._strip_protocol(path)
         out = dict()
         detail = kwargs.pop("detail", False)
-        for path_, dirs, files in self.walk(path, maxdepth, detail=True, **kwargs):
+        for _, dirs, files in self.walk(path, maxdepth, detail=True, **kwargs):
             if withdirs:
                 files.update(dirs)
             out.update({info["name"]: info for name, info in files.items()})

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -427,7 +427,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
         path = self._strip_protocol(path)
         out = dict()
         detail = kwargs.pop("detail", False)
-        for path, dirs, files in self.walk(path, maxdepth, detail=True, **kwargs):
+        for path_, dirs, files in self.walk(path, maxdepth, detail=True, **kwargs):
             if withdirs:
                 files.update(dirs)
             out.update({info["name"]: info for name, info in files.items()})

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -6,6 +6,7 @@ import pytest
 
 import fsspec
 from fsspec.implementations.ftp import FTPFileSystem
+from fsspec.implementations.http import HTTPFileSystem
 from fsspec.spec import AbstractFileSystem, AbstractBufferedFile
 
 
@@ -176,6 +177,57 @@ def test_expand_path_recursive(test_paths, expected):
     # test with all queries
     paths = test_fs.expand_path(list(test_paths), recursive=True)
     assert sorted(paths) == sorted(expected)
+
+
+@pytest.mark.parametrize(
+    ["filesystem", "host", "test_path", "expected"],
+    [
+        (
+            FTPFileSystem,
+            "ftp.fau.de",
+            "ftp://ftp.fau.de/debian-cd/current/amd64/log/success",
+            [
+                "/debian-cd/current/amd64/log/success/BD.log",
+                "/debian-cd/current/amd64/log/success/DLBD.log",
+                "/debian-cd/current/amd64/log/success/DVD.log",
+                "/debian-cd/current/amd64/log/success/EDUNI.log",
+                "/debian-cd/current/amd64/log/success/EDUUSB.log",
+                "/debian-cd/current/amd64/log/success/MACNI.log",
+                "/debian-cd/current/amd64/log/success/NI.log",
+                "/debian-cd/current/amd64/log/success/USB16G.log",
+                "/debian-cd/current/amd64/log/success/XFCECD.log",
+            ],
+        ),
+        (
+            HTTPFileSystem,
+            "https://ftp.fau.de",
+            "https://ftp.fau.de/debian-cd/current/amd64/log/success",
+            [
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success",
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success/?C=D;O=A",
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success/?C=M;O=A",
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success/?C=N;O=D",
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success/?C=S;O=A",
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success/BD.log",
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success/DLBD.log",
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success/DVD.log",
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success/EDUNI.log",
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success/EDUUSB.log",
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success/MACNI.log",
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success/NI.log",
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success/USB16G.log",
+                "https://ftp.fau.de/debian-cd/current/amd64/log/success/XFCECD.log",
+            ],
+        ),
+    ],
+)
+def test_find(filesystem, host, test_path, expected):
+    """ Test .find() method on debian server (available as ftp and https) with constant folder """
+    test_fs = filesystem(host)
+
+    filenames = test_fs.find(test_path)
+
+    assert filenames == expected
 
 
 def test_find_details():


### PR DESCRIPTION
At #506 we've seen that when using the HTTPFileSystem's ``find`` method, it appears that the method would randomly add one of the found directories to the returned files listing. This is due to conflicting variable naming here:
https://github.com/intake/filesystem_spec/blob/a5bb95155b450ec2443872a45a4a58ce90748297/fsspec/spec.py#L430-L437

To fix this I renamed resulting **path** from ``self.walk()`` to **path_**. See here:
https://github.com/earthobservations/filesystem_spec/blob/e3956827181393b30a57ab6d11ede52931a4dec8/fsspec/spec.py#L430-L437
