### PR TITLE
Remove tests and docs from install package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,6 @@ include fsspec/_version.py
 include LICENSE
 include README.rst
 include requirements.txt
+prune docs
+prune fsspec/tests
+prune fsspec/implementations/tests


### PR DESCRIPTION
Sure, you can't run tests, but you should do that against the
checked-out repo

xref https://github.com/intake/filesystem_spec/pull/504

Is there any downside to this?