### PR TITLE
Fix cache clearing with DirCache.listings_expiry_time=0

### DIFF
--- a/fsspec/dircache.py
+++ b/fsspec/dircache.py
@@ -54,7 +54,7 @@ class DirCache(MutableMapping):
         self.max_paths = max_paths
 
     def __getitem__(self, item):
-        if self.listings_expiry_time:
+        if self.listings_expiry_time is not None:
             if self._times.get(item, 0) - time.time() < -self.listings_expiry_time:
                 del self._cache[item]
         if self.max_paths:
@@ -80,7 +80,7 @@ class DirCache(MutableMapping):
         if self.max_paths:
             self._q(key)
         self._cache[key] = value
-        if self.listings_expiry_time:
+        if self.listings_expiry_time is not None:
             self._times[key] = time.time()
 
     def __delitem__(self, key):


### PR DESCRIPTION
The docstring for `DirCache.listings_expiry_time` says `None` will disable cache expiration, but does not specify the behavior for `listings_expiry_time=0` (or <0):

https://github.com/intake/filesystem_spec/blob/993a967161250b7ebd736a10a9bf811b0e44a744/fsspec/dircache.py#L41-L43

The docstring for `GCSFileSystem.cache_timeout` (which is passed directly to `DirCache.listings_expiry_time`) implies `cache_timeout=0` should result in no caching:

https://github.com/dask/gcsfs/blob/b94b9c187129b144e46d5f78ef37e21e39746be2/gcsfs/core.py#L202-L204

Does this seem like the "right" fix/intended behavior, though it might be a bit of a behavior change?