### PR TITLE
Add dbfs to the changelog and docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -98,6 +98,7 @@ Built-in Implementations
    fsspec.implementations.smb.SMBFileSystem
    fsspec.implementations.jupyter.JupyterFileSystem
    fsspec.implementations.libarchive.LibArchiveFileSystem
+   fsspec.implementations.dbfs.DatabricksFileSystem
    fsspec.implementations.reference.ReferenceFileSystem
 
 .. autoclass:: fsspec.implementations.ftp.FTPFileSystem
@@ -149,6 +150,9 @@ Built-in Implementations
    :members: __init__
 
 .. autoclass:: fsspec.implementations.libarchive.LibArchiveFileSystem
+   :members: __init__
+
+.. autoclass:: fsspec.implementations.dbfs.DatabricksFileSystem
    :members: __init__
 
 .. autoclass:: fsspec.implementations.reference.ReferenceFileSystem

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 Dev
 -------------
 
+Features:
+
+- Add dbfs:// support
+
 Fixes:
 
 - random appending of a directory within the filesystems ``find()`` method


### PR DESCRIPTION
As discussed in #504, this PR adds dbfs to the changelog and to the API documentation. If there are more places where it should be added, please tell me :-)