### PR TITLE
Add support for filesystem discovery via entry points

### DIFF
--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -1,7 +1,11 @@
 try:
     from importlib.metadata import entry_points
 except ImportError:  # python < 3.8
-    from importlib_metadata import entry_points
+    try:
+        from importlib_metadata import entry_points
+    except ImportError:
+        entry_points = None
+
 
 from . import caching
 from ._version import get_versions
@@ -34,7 +38,8 @@ __all__ = [
     "caching",
 ]
 
-entry_points = entry_points()
-for spec in entry_points.get("fsspec.specs", []):
-    err_msg = f"Unable to load filesystem from {spec}"
-    register_implementation(spec.name, spec.module, errtxt=err_msg)
+if entry_points is not None:
+    entry_points = entry_points()
+    for spec in entry_points.get("fsspec.specs", []):
+        err_msg = f"Unable to load filesystem from {spec}"
+        register_implementation(spec.name, spec.module, errtxt=err_msg)

--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -1,15 +1,19 @@
-from ._version import get_versions
+try:
+    from importlib.metadata import entry_points
+except ImportError:  # python < 3.8
+    from importlib_metadata import entry_points
 
-from .spec import AbstractFileSystem
-from .registry import (
-    get_filesystem_class,
-    registry,
-    filesystem,
-    register_implementation,
-)
-from .mapping import FSMap, get_mapper
-from .core import open_files, get_fs_token_paths, open, open_local
 from . import caching
+from ._version import get_versions
+from .core import get_fs_token_paths, open, open_files, open_local
+from .mapping import FSMap, get_mapper
+from .registry import (
+    filesystem,
+    get_filesystem_class,
+    register_implementation,
+    registry,
+)
+from .spec import AbstractFileSystem
 
 __version__ = get_versions()["version"]
 del get_versions
@@ -29,3 +33,8 @@ __all__ = [
     "registry",
     "caching",
 ]
+
+entry_points = entry_points()
+for spec in entry_points.get("fsspec.specs", []):
+    err_msg = f"Unable to load filesystem from {spec}"
+    register_implementation(spec.name, spec.module, errtxt=err_msg)

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -80,10 +80,14 @@ class _Cached(type):
 
 pa_version = get_package_version_without_import("pyarrow")
 if pa_version and LooseVersion(pa_version) < LooseVersion("2.0"):
-    import pyarrow as pa
+    try:
+        import pyarrow as pa
 
-    up = pa.filesystem.DaskFileSystem
-else:
+        up = pa.filesystem.DaskFileSystem
+    except ImportError:  # pragma: no cover
+        # pyarrow exists but doesn't import for some reason
+        up = object
+else:  # pragma: no cover
     up = object
 
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     python_requires=">3.6",
     install_requires=open("requirements.txt").read().strip().split("\n"),
     extras_require={
+        ":python_version < '3.8'": ['importlib_metadata'],
         "abfs": ["adlfs"],
         "adl": ["adlfs"],
         "dask": ["dask", "distributed"],

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ conda_deps=
 deps=
     hadoop-test-cluster==0.1.0
     smbprotocol
+    py36,py37: importlib_metadata
 
 [testenv]
 description=Run test suite against target versions.
@@ -46,7 +47,7 @@ conda_deps=
 deps=
     {[core]deps}
 commands =
-    py.test --cov=fsspec -v -r s
+    py.test --cov=fsspec -v -r s {posargs}
 passenv = CIRUN
 
 [testenv:s3fs]


### PR DESCRIPTION
Fixes #206 

Uses [importlib.metadata](https://docs.python.org/3.8/library/importlib.metadata.html#entry-points) when available in stdlib (or falls back to the [backport](https://pypi.org/project/importlib-metadata/) otherwise) to scan for installed packages with the `fsspec.specs` entry point defined and add all such entry points to `known_implementations` upon import.

### Example
setup.py
``` python
from setuptools import setup

setup(
    name="myfs",
    version='1.0.0',
    packages=['myfs'],
    entry_points=[
        'fsspec.specs': [
            'myfs=myfs:MyFs',
        ]
    ],
)
```

myfs/__init__.py
``` python
from fsspec import AbstractFileSystem

class MyFs(AbstractFileSystem):
    pass
```
### Future Work:

- Maybe break existing implementations out into their own packages
- Documentation entry