### PR TITLE
DOC: cell blocks for installs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,14 +29,20 @@ These are described further in the :doc:`features` section.
 Installation
 ------------
 
+.. code-block:: sh
+
    pip install fsspec
 
 Not all included filesystems are usable by default without installing extra
-dependencies. For example to be able to access data in S3::
+dependencies. For example to be able to access data in S3:
+
+.. code-block:: sh
 
    pip install fsspec[s3]
 
 or
+
+.. code-block:: sh
 
    conda install -c conda-forge fsspec
 


### PR DESCRIPTION
Can't say i've built the docs but the current page is missing some cell blocks

https://filesystem-spec.readthedocs.io/en/latest/index.html

![Screen Shot 2021-02-09 at 4 09 17 PM](https://user-images.githubusercontent.com/17162724/107428880-3d1e7180-6af1-11eb-8efc-5df4816a8463.png)
