### PR TITLE
document the use of entry_points to register new backends

### DIFF
--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -66,7 +66,27 @@ We may eventually refactor ``AbstractFileSystem`` to split the default implement
 the set of methods that you might implement in a new backend, and the
 documented end-user API.
 
-For now, new backends must register themselves on import
+In order to register a new backend with fsspec, new backends should register
+themselves using the `entry_points <https://setuptools.readthedocs.io/en/latest/userguide/quickstart.html#entry-points-and-automatic-script-creation>`_
+facility from setuptools. In particular, if you want to register a new
+filesystem protocol ``myfs`` which is provided by the ``MyFS`` class in
+the ``myfs`` package, add the following to your ``setup.py``:
+
+.. code-block:: python
+
+    setuptools.setup(
+        ...
+        entry_points={
+            'fsspec.specs': [
+                'myfs=myfs.MyFS',
+            ],
+        },
+        ...
+    )
+
+
+Alternatively, the previous method of registering a new backend can be used.
+That is, new backends must register themselves on import
 (``register_implementation``) or post a PR to the ``fsspec`` repo
 asking to be included in ``fsspec.registry.known_implementations``.
 

--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -42,4 +42,4 @@ if entry_points is not None:
     entry_points = entry_points()
     for spec in entry_points.get("fsspec.specs", []):
         err_msg = f"Unable to load filesystem from {spec}"
-        register_implementation(spec.name, spec.value.replace(':', '.'), errtxt=err_msg)
+        register_implementation(spec.name, spec.value.replace(":", "."), errtxt=err_msg)

--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -42,4 +42,4 @@ if entry_points is not None:
     entry_points = entry_points()
     for spec in entry_points.get("fsspec.specs", []):
         err_msg = f"Unable to load filesystem from {spec}"
-        register_implementation(spec.name, spec.module, errtxt=err_msg)
+        register_implementation(spec.name, spec.value.replace(':', '.'), errtxt=err_msg)


### PR DESCRIPTION
I just found out that registering new backends is now possible using `entry_points`, thanks to #515. I think that this feature needs at least some basic documentation, so this is what this PR is for.

One think to **note** is that it actually works a little different from what is written in #515:

This is from the [initial message in 515](https://github.com/intake/filesystem_spec/pull/515#issue-548432617)
>```python
>    entry_points=[
>        'fsspec.specs': [
>            'myfs=myfs:MyFs',
>        ]
>    ],
>```

and this is what actually works:

```python
    entry_points={
        'fsspec.specs': [
            'myfs=myfs.MyFS',
        ],  
    },
```

The change of `[]` to `{}` seems to be a typo, but I am not sure if that is the case for `:` -> `.`. According to the [setuptools manual](https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html), the syntax for defining entry points is:

```
<name> = [<package>.[<subpackage>.]]<module>[:<object>.<object>]
```

and thus the original comment in #515 would be correct in this regard, but the code is maybe wrong.

---

This PR documents what currently works. But probably we should change the code and the docs such that the filesystem **object** will be separated by a `:` in the `entry_points`.