### PR TITLE
RF/BF: http - do not _fetch_all if file is smaller than blocksize/requested

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -431,6 +431,8 @@ class HTTPFile(AbstractBufferedFile):
         """
         if (
             (length < 0 and self.loc == 0)  # explicit read all
+            # but not when the size is known and fits into a block anyways
+            and not (self.size is not None and self.size <= self.blocksize)
         ):
             self._fetch_all()
         if self.size is None:

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -430,11 +430,7 @@ class HTTPFile(AbstractBufferedFile):
             read only part of the data will raise a ValueError.
         """
         if (
-            (length < 0 and self.loc == 0)
-            or (length > (self.size or length))  # explicit read all
-            or (  # read more than there is
-                self.size and self.size < self.blocksize
-            )  # all fits in one block anyway
+            (length < 0 and self.loc == 0)  # explicit read all
         ):
             self._fetch_all()
         if self.size is None:


### PR DESCRIPTION
This should prevent `_fetch_all` to overload the .cache with AllBytes
within async_fetch_all and thus use originally provided .cache and
store file on disk.

It is just a partial remedy/workaround to
https://github.com/intake/filesystem_spec/issues/553
and a proper solution is likely needing RFing so async_fetch_all could
feed the original .cache with the data for all blocks.

I just was looking around and decided not to stay silent and propose a PR -- feel free to drop it, but it seems to resolve the issue in my sample case at least and might give food for thought ;-)