### PR TITLE
Enable listings cache for HTTP filesystem

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,7 @@ Enhancements
 - better link and size finding for HTTP (#610, %99)
 - link following in Local (#608)
 - ReferenceFileSystem dev (#606, #604, #602)
+- Enable listings cache for HTTP filesystem (#560)
 
 Fixes
 

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -106,6 +106,36 @@ def test_list(server):
     assert out == [server + "/index/realfile"]
 
 
+def test_list_invalid_args(server):
+    with pytest.raises(TypeError):
+        h = fsspec.filesystem("http", use_foobar=True)
+        h.glob(server + "/index/*")
+
+
+def test_list_cache(server):
+    h = fsspec.filesystem("http", use_listings_cache=True)
+    out = h.glob(server + "/index/*")
+    assert out == [server + "/index/realfile"]
+
+
+def test_list_cache_with_expiry_time(server):
+    h = fsspec.filesystem("http", use_listings_cache=True, listings_expiry_time=30)
+    out = h.glob(server + "/index/*")
+    assert out == [server + "/index/realfile"]
+
+
+def test_list_cache_with_max_paths(server):
+    h = fsspec.filesystem("http", use_listings_cache=True, max_paths=5)
+    out = h.glob(server + "/index/*")
+    assert out == [server + "/index/realfile"]
+
+
+def test_list_cache_with_skip_instance_cache(server):
+    h = fsspec.filesystem("http", use_listings_cache=True, skip_instance_cache=True)
+    out = h.glob(server + "/index/*")
+    assert out == [server + "/index/realfile"]
+
+
 def test_isdir(server):
     h = fsspec.filesystem("http")
     assert h.isdir(server + "/index/")


### PR DESCRIPTION
Dear Martin,

we recognized your activity on the code base again and feared we would have missed some merge window already. So, we tried to hurry to bring in this patch I had slumbering on my workstation for some time already.

The patch will enable listings caching for the HTTP filesystem implementation. It is accompanied by appropriate tests and I will be happy if you could take the time to look into it and consider it for the next release if you like it. Please let us know about any amendments you would like to see.

With kind regards,
Andreas.

P.S.: After @gutzbenj submitted #507 the other day, this patch would be the last thing we would need for finally getting rid of the dbmfile-based cache we still use within Wetterdienst, see https://github.com/earthobservations/wetterdienst/issues/243. Because of this, we haven't migrated the code base to `filesystem_spec` yet, but would be very keen doing so.

On the CI side, as the old cache implementation is apparently not thread-safe (https://github.com/earthobservations/wetterdienst/pull/254#issuecomment-733946897), this would hopefully enable us to run all tests in parallel using [pytest-xdist](https://pypi.org/project/pytest-xdist), see https://github.com/earthobservations/wetterdienst/issues/253. At the same time, it would be a tremendous improvement for our users and also for ourselves, as we would be able to remove some code from the code base and stand on the shoulders of `filesystem_spec`.
