### PR TITLE
Libarchive implementation enhaced to support any filesystem with seekable files

### DIFF
--- a/fsspec/implementations/libarchive.py
+++ b/fsspec/implementations/libarchive.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from contextlib import contextmanager
-
 from ctypes import (
     CFUNCTYPE,
     POINTER,

--- a/fsspec/implementations/libarchive.py
+++ b/fsspec/implementations/libarchive.py
@@ -2,17 +2,18 @@ from __future__ import absolute_import, division, print_function
 
 from contextlib import contextmanager
 
-import libarchive
-import libarchive.ffi as ffi
 from ctypes import (
+    CFUNCTYPE,
+    POINTER,
     c_int,
     c_longlong,
     c_void_p,
-    CFUNCTYPE,
-    POINTER,
     cast,
     create_string_buffer,
 )
+
+import libarchive
+import libarchive.ffi as ffi
 
 from fsspec import AbstractFileSystem, open_files
 from fsspec.implementations.memory import MemoryFile


### PR DESCRIPTION
The libarchive implementation was until now only supporting local files (with a file descriptor).

By implementing some low level code (not currently implemented in the python wrapper around the libarchive c library), we can read any file-like object which supports readinto seek (and tell), which covers the vast majority.

Note: libarchive was designed specifically for streaming data with no seek capability (tape recorders, sockets and so on). This is supported only for certain archive types (the most simpler?) and while extracting ALL the data. In any case, since the file system implementation allows for any file access we read the complete archive entries skipping the data, and this requires "seeking" capabilities.