### PR TITLE
Fix CachingFileSystem behaviour for equality testing, hashing, and JSON representation.

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -455,7 +455,7 @@ class CachingFileSystem(AbstractFileSystem):
         Not implemented yet for CachingFileSystem.
         """
         raise NotImplementedError(
-            "CachingFileSystem JSON representation not " "implemented"
+            "CachingFileSystem JSON representation not implemented"
         )
 
 

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -382,6 +382,9 @@ class CachingFileSystem(AbstractFileSystem):
             "open_many",
             "commit_many",
             "hash_name",
+            "__hash__",
+            "__eq__",
+            "to_json",
         ]:
             # all the methods defined in this class. Note `open` here, since
             # it calls `_open`, but is actually in superclass
@@ -415,6 +418,40 @@ class CachingFileSystem(AbstractFileSystem):
         else:
             # attributes of the superclass, while target is being set up
             return super().__getattribute__(item)
+
+    def __eq__(self, other):
+        """Test for equality."""
+        if self is other:
+            return True
+        if not isinstance(other, type(self)):
+            return False
+        return (self.storage == other.storage
+                and self.kwargs == other.kwargs
+                and self.cache_check == other.cache_check
+                and self.check_files == other.check_files
+                and self.expiry == other.expiry
+                and self.compression == other.compression
+                and self.same_names == other.same_names
+                and self.target_protocol == other.target_protocol)
+
+    def __hash__(self):
+        """Calculate hash."""
+        return (hash(tuple(self.storage))
+                ^ hash(str(self.kwargs))
+                ^ hash(self.cache_check)
+                ^ hash(self.check_files)
+                ^ hash(self.expiry)
+                ^ hash(self.compression)
+                ^ hash(self.same_names)
+                ^ hash(self.target_protocol))
+
+    def to_json(self):
+        """Calculate JSON representation.
+
+        Not implemented yet for CachingFileSystem.
+        """
+        raise NotImplementedError("CachingFileSystem JSON representation not "
+                                  "implemented")
 
 
 class WholeFileCacheFileSystem(CachingFileSystem):

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -425,33 +425,38 @@ class CachingFileSystem(AbstractFileSystem):
             return True
         if not isinstance(other, type(self)):
             return False
-        return (self.storage == other.storage
-                and self.kwargs == other.kwargs
-                and self.cache_check == other.cache_check
-                and self.check_files == other.check_files
-                and self.expiry == other.expiry
-                and self.compression == other.compression
-                and self.same_names == other.same_names
-                and self.target_protocol == other.target_protocol)
+        return (
+            self.storage == other.storage
+            and self.kwargs == other.kwargs
+            and self.cache_check == other.cache_check
+            and self.check_files == other.check_files
+            and self.expiry == other.expiry
+            and self.compression == other.compression
+            and self.same_names == other.same_names
+            and self.target_protocol == other.target_protocol
+        )
 
     def __hash__(self):
         """Calculate hash."""
-        return (hash(tuple(self.storage))
-                ^ hash(str(self.kwargs))
-                ^ hash(self.cache_check)
-                ^ hash(self.check_files)
-                ^ hash(self.expiry)
-                ^ hash(self.compression)
-                ^ hash(self.same_names)
-                ^ hash(self.target_protocol))
+        return (
+            hash(tuple(self.storage))
+            ^ hash(str(self.kwargs))
+            ^ hash(self.cache_check)
+            ^ hash(self.check_files)
+            ^ hash(self.expiry)
+            ^ hash(self.compression)
+            ^ hash(self.same_names)
+            ^ hash(self.target_protocol)
+        )
 
     def to_json(self):
         """Calculate JSON representation.
 
         Not implemented yet for CachingFileSystem.
         """
-        raise NotImplementedError("CachingFileSystem JSON representation not "
-                                  "implemented")
+        raise NotImplementedError(
+            "CachingFileSystem JSON representation not " "implemented"
+        )
 
 
 class WholeFileCacheFileSystem(CachingFileSystem):

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -788,6 +788,7 @@ def test_equality():
     assert hash(cfs2) == hash(cfs3)
 
 
+@pytest.mark.xfail
 def test_json():
     """Test that the JSON representation refers to correct class.
 

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -763,16 +763,11 @@ def test_equality():
     Related: GitHub#577, GitHub#578
     """
     from fsspec.implementations.local import LocalFileSystem
+
     lfs = LocalFileSystem()
-    cfs1 = CachingFileSystem(
-        fs=lfs,
-        cache_storage="raspberry")
-    cfs2 = CachingFileSystem(
-        fs=lfs,
-        cache_storage="banana")
-    cfs3 = CachingFileSystem(
-        fs=lfs,
-        cache_storage="banana")
+    cfs1 = CachingFileSystem(fs=lfs, cache_storage="raspberry")
+    cfs2 = CachingFileSystem(fs=lfs, cache_storage="banana")
+    cfs3 = CachingFileSystem(fs=lfs, cache_storage="banana")
     assert cfs1 == cfs1
     assert cfs1 != cfs2
     assert cfs1 != cfs3
@@ -797,9 +792,8 @@ def test_json():
     """
     import json
     from fsspec.implementations.local import LocalFileSystem
+
     lfs = LocalFileSystem()
-    cfs = CachingFileSystem(
-        fs=lfs,
-        cache_storage="raspberry")
+    cfs = CachingFileSystem(fs=lfs, cache_storage="raspberry")
     D = json.loads(cfs.to_json())
     assert D["cls"].endswith("CachingFileSystem")

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -791,6 +791,7 @@ def test_json():
     CachingFileSystem, not to the underlying filesystem.
     """
     import json
+
     from fsspec.implementations.local import LocalFileSystem
 
     lfs = LocalFileSystem()


### PR DESCRIPTION
A CachingFileSystem currently delegates equality testing, hashing, and JSON representation to the underlying class.  This has the undesirable effect that different CachingFileSystems compare when their underlying file system is the same, even if they have different properties.

This is still a work in progress.

- [x] Fixes #576 
- [x] Fixes #577 
- [x] Tests added
- [x] Tests passed