### PR TITLE
WIP: Remove nested async by copying code

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -178,7 +178,7 @@ class ReferenceFileSystem(AsyncFileSystem):
 
             self.dircache[par].append({"name": path, "type": "file", "size": size})
 
-    def ls(self, path, detail=True, **kwargs):
+    async def _ls(self, path, detail=True, **kwargs):
         path = self._strip_protocol(path)
         out = self._ls_from_cache(path)
         if detail:

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -1,24 +1,10 @@
-import asyncio
-import sys
+import inspect
 
-import pytest
-
-from fsspec.asyn import _run_until_done
+import fsspec.asyn
 
 
-async def inner():
-    await asyncio.sleep(1)
-    return True
-
-
-async def outer():
-    await asyncio.sleep(1)
-    return _run_until_done(asyncio.get_running_loop(), inner())
-
-
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="Async fails on py36")
-def test_runtildone():
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    assert loop.run_until_complete(outer())
-    loop.close()
+def test_sync_methods():
+    inst = fsspec.asyn.AsyncFileSystem()
+    assert inspect.iscoroutinefunction(inst._info)
+    assert hasattr(inst, "info")
+    assert not inspect.iscoroutinefunction(inst.info)


### PR DESCRIPTION
Major change to async code!

All nested calls to sync removed, by copying code such as walk() from spec to asyn. All async method only call async methods, and an attempt to do otherwise raises NotImplemented. In fact, _run_until_complete is *gone*. This is how it should have been written from the start (except that some copied code could clearly be factored out).

cc @hayesgb , this surely affects azure
s3fs and gcsfs already have conforming code locally I will push when we agree on this change.