### PR TITLE
Allow for URL ref without offset/size

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -86,8 +86,12 @@ class ReferenceFileSystem(AsyncFileSystem):
             return part
         elif isinstance(part, str):
             return part.encode()
-        url, start, size = part
-        end = start + size
+
+        if len(part) == 1:
+            url, start, end = part[0], None, None
+        else:
+            url, start, size = part
+            end = start + size
         if url is None:
             url = self.target
         return await self.fs._cat_file(url, start=start, end=end)
@@ -134,10 +138,10 @@ class ReferenceFileSystem(AsyncFileSystem):
                     self.references[k] = base64.b64decode(v[7:])
                 self.references[k] = v
             else:
-                u, off, l = v
+                u = v[0]
                 if "{{" in u:
                     u = jinja2.Template(u).render(**templates)
-                self.references[k] = [u, off, l]
+                self.references[k] = [u] if len(v) == 1 else [u, v[1], v[2]]
         for gen in references.get("gen", []):
             dimension = {
                 k: v
@@ -162,6 +166,8 @@ class ReferenceFileSystem(AsyncFileSystem):
         for path, part in self.references.items():
             if isinstance(part, (bytes, str)):
                 size = len(part)
+            elif len(part) == 1:
+                size = None
             else:
                 _, start, end = part
                 size = end - start

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -88,7 +88,9 @@ class ReferenceFileSystem(AsyncFileSystem):
             return part.encode()
 
         if len(part) == 1:
-            url, start, end = part[0], None, None
+            url = part[0]
+            start = None
+            end = None
         else:
             url, start, size = part
             end = start + size

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -112,6 +112,7 @@ def test_spec1_expand():
             "key1": ["http://target_url", 10000, 100],
             "key2": ["http://{{u}}", 10000, 100],
             "key3": ["http://{{f(c='text')}}", 10000, 100],
+            "key4": ["http://target_url"],
         },
     }
     fs = fsspec.filesystem("reference", references=in_data, target_protocol="http")
@@ -120,6 +121,7 @@ def test_spec1_expand():
         "key1": ["http://target_url", 10000, 100],
         "key2": ["http://server.domain/path", 10000, 100],
         "key3": ["http://text", 10000, 100],
+        "key4": ["http://target_url"],
         "gen_key0": ["http://server.domain/path_0", 1000, 1000],
         "gen_key1": ["http://server.domain/path_1", 2000, 1000],
         "gen_key2": ["http://server.domain/path_2", 3000, 1000],


### PR DESCRIPTION
I took a look at the Reference V1 implementation, and noticed a `[url]` reference (no offset/size) wasn't currently supported. It is my understanding this is part of the spec and I have attempted to add support in this PR.