### PR TITLE
Fix empty subdirs in walk when detail=True

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -274,7 +274,10 @@ class AsyncFileSystem(AbstractFileSystem):
         try:
             listing = await self._ls(path, detail=True, **kwargs)
         except (FileNotFoundError, IOError):
-            yield [], [], []
+            if detail:
+                yield path, {}, {}
+            else:
+                yield path, [], []
             return
 
         for info in listing:

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -385,7 +385,9 @@ class AbstractFileSystem(up, metaclass=_Cached):
         try:
             listing = self.ls(path, detail=True, **kwargs)
         except (FileNotFoundError, IOError):
-            return [], [], []
+            if detail:
+                return path, {}, {}
+            return path, [], []
 
         for info in listing:
             # each info name must be at least [path]/part , but here


### PR DESCRIPTION
Fixes #601 for the case of maxdepth not none and withdirs=True