### PR TITLE
Add exists as core method to fsspec

### DIFF
--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -9,7 +9,7 @@ except ImportError:  # python < 3.8
 
 from . import caching
 from ._version import get_versions
-from .core import get_fs_token_paths, open, open_files, open_local
+from .core import get_fs_token_paths, open, open_files, open_local, exists
 from .mapping import FSMap, get_mapper
 from .registry import (
     filesystem,
@@ -34,6 +34,7 @@ __all__ = [
     "open",
     "open_files",
     "open_local",
+    "exists",
     "registry",
     "caching",
 ]

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -437,6 +437,36 @@ def open(
         **kwargs,
     )[0]
 
+def exists(
+    urlpath,
+    protocol=None,
+    **kwargs,
+):
+    """Given a path or paths, return whether a file exists.
+
+    Parameters
+    ----------
+    urlpath: string or list
+        Absolute or relative filepath. Prefix with a protocol like ``s3://``
+        to read from alternative filesystems. Should not include glob
+        character(s).
+    protocol: str or None
+        If given, overrides the protocol found in the URL.
+    **kwargs: dict
+        Extra options that make sense to a particular storage connection, e.g.
+        host, port, username, password, etc.
+
+    Returns
+    -------
+    ``Boolean`` of whether the file exists.
+    """
+    fs, _, paths = get_fs_token_paths(
+        urlpath,
+        storage_options=kwargs,
+        protocol=protocol,
+    )
+    return fs.exists(paths[0])
+
 
 def open_local(url, mode="rb", **storage_options):
     """Open file(s) which can be resolved to local

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -263,3 +263,17 @@ def test_chained_url(ftp_writable):
         url += f"::ftp://{username}:{password}@{host}:{port}/archive.zip"
         with fsspec.open(url, "rb") as f:
             assert f.read() == data["afile"]
+
+@pytest.mark.run
+def test_exists(m):
+    mpath = "/test_exists_file"
+
+    # Cycle through twice to catch all transitions
+    for _ in range(2):
+        m.touch(mpath)
+        assert fsspec.exists("memory://" + mpath) == True
+        m.rm(mpath)
+        assert fsspec.exists("memory://" + mpath) == False
+
+
+        


### PR DESCRIPTION
Several times, I've used fsspec and been disappointed that there hasn't been an "exists" function on the top level, in the exact same way that there's an "open" function on the top level. 

This pull adds one!

Let me know if you don't think this is a good addition for whatever reason.