### PR TITLE
Add s3a:// as an alias for s3://

### DIFF
--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -135,6 +135,7 @@ known_implementations = {
         "err": 'webHDFS access requires "requests" to be installed',
     },
     "s3": {"class": "s3fs.S3FileSystem", "err": "Install s3fs to access S3"},
+    "s3a": {"class": "s3fs.S3FileSystem", "err": "Install s3fs to access S3"},
     "adl": {
         "class": "adlfs.AzureDatalakeFileSystem",
         "err": "Install adlfs to access Azure Datalake Gen1",

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -201,7 +201,7 @@ def test_infer_options():
     # include it in the path. Test that:
     # - Parsing doesn't lowercase the bucket
     # - The bucket is included in path
-    for protocol in ["s3", "gcs", "gs"]:
+    for protocol in ["s3", "s3a", "gcs", "gs"]:
         options = infer_storage_options("%s://Bucket-name.com/test.csv" % protocol)
         assert options["path"] == "Bucket-name.com/test.csv"
 

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -71,7 +71,7 @@ def infer_storage_options(urlpath, inherit_storage_options=None):
         # https://github.com/dask/dask/issues/1417
         options["host"] = parsed_path.netloc.rsplit("@", 1)[-1].rsplit(":", 1)[0]
 
-        if protocol in ("s3", "gcs", "gs"):
+        if protocol in ("s3", "s3a", "gcs", "gs"):
             options["path"] = options["host"] + options["path"]
         else:
             options["host"] = options["host"]


### PR DESCRIPTION
s3fs operates on both `s3://` and `s3a://`-style protocols. We might consider doing the same for fsspec.