### PR TITLE
Update stringify_path to work with legacy ParquetDatasetPiece

### DIFF
--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -307,7 +307,11 @@ def stringify_path(filepath):
         return filepath.__fspath__()
     elif isinstance(filepath, pathlib.Path):
         return str(filepath)
-    return filepath
+    else:
+        try:
+            return str(filepath)
+        except Exception:
+            return filepath
 
 
 def make_instance(cls, args, kwargs):

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -307,11 +307,10 @@ def stringify_path(filepath):
         return filepath.__fspath__()
     elif isinstance(filepath, pathlib.Path):
         return str(filepath)
+    elif hasattr(filepath, "path"):
+        return filepath.path
     else:
-        try:
-            return str(filepath)
-        except Exception:
-            return filepath
+        return filepath
 
 
 def make_instance(cls, args, kwargs):


### PR DESCRIPTION
Update the `stringify_path` method to return a string, if the object can be coerced to string.

A lot of the tests in https://github.com/dask/dask/pull/7303 are currently failing. This looks like it's because the legacy pyarrow test cases in dask are trying to pass a `ParquetDatasetPiece` object through the `stringify_path` method of `fsspec`, which isn't converting it to a string.

When I make the change in this PR, and then re-run the dask tests for https://github.com/dask/dask/pull/7303 many fewer tests fail. (There are probably some unrelated things in dask that still need to be tidied up, but I haven't looked into those test failures yet).

