### PR TITLE
Update documentation to better reflect how PyArrow interoperability works

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -94,20 +94,20 @@ object.
 PyArrow integration
 -------------------
 
-.. warning::
-    ``fsspec`` is only compatible with PyArrow's classic ``FileSystem``. Starting with version
-    2.0 (released in October 2020), `pyarrow`_ switched to a C++ filesystem implementation that
-    is no longer compatible with ``fsspec``. Please refer to 
-    `this GitHub issue <https://github.com/intake/filesystem_spec/issues/295>`_ for additional details.
-
-
-`pyarrow`_ has its own internal idea of what a file-system is (``pyarrow.filesystem.FileSystem``),
+`pyarrow`_ has its own internal idea of what a file-system is (``pyarrow.fs.FileSystem``),
 and some functions, particularly the loading of parquet, require that the target be compatible.
 As it happens, the design of the file-system interface in ``pyarrow`` *is* compatible with ``fsspec``
-(this is not by accident). Therefore at import time, ``fsspec`` checks for the existence of
-``pyarrow``, and, if found, adds it to the superclasses of the spec base-class. In this manner,
-all ``fsspec``-derived file-systems are also pyarrow file-systems, and can be used by pyarrow
-functions.
+(this is not by accident). 
+
+At import time, ``fsspec`` checks for the existence of ``pyarrow``, and, if ``pyarrow < 2.0`` is 
+found, adds its base filesystem to the superclasses of the spec base-class.
+For ``pyarrow >= 2.0``, ``fsspec`` file systems can simply be passed to ``pyarrow`` functions 
+that expect ``pyarrow`` filesystems, and ``pyarrow`` `will automatically wrap them
+<https://arrow.apache.org/docs/python/filesystems.html#using-fsspec-compatible-filesystems>`_.
+
+In this manner, all ``fsspec``-derived file-systems are also ``pyarrow`` file-systems, and can be used
+by ``pyarrow`` functions.
+
 
 .. _pyarrow: https://arrow.apache.org/docs/python/
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -94,9 +94,16 @@ object.
 PyArrow integration
 -------------------
 
+.. warning::
+    ``fsspec`` is only compatible with PyArrow's classic ``FileSystem``. Starting with version
+    2.0 (released in October 2020), `pyarrow`_ switched to a C++ filesystem implementation that
+    is no longer compatible with ``fsspec``. Please refer to 
+    `this GitHub issue https://github.com/intake/filesystem_spec/issues/295`_ for additional details.
+
+
 `pyarrow`_ has its own internal idea of what a file-system is (``pyarrow.filesystem.FileSystem``),
 and some functions, particularly the loading of parquet, require that the target be compatible.
-As it happens, the design of the file-system interface in ``pyarrow`` *is* compatible with `fsspec`
+As it happens, the design of the file-system interface in ``pyarrow`` *is* compatible with ``fsspec``
 (this is not by accident). Therefore at import time, ``fsspec`` checks for the existence of
 ``pyarrow``, and, if found, adds it to the superclasses of the spec base-class. In this manner,
 all ``fsspec``-derived file-systems are also pyarrow file-systems, and can be used by pyarrow
@@ -377,7 +384,7 @@ Obviously, you should only define default values that are appropriate for
 a given file system implementation. INI files only support string values.
 
 Alternatively, you can provide overrides with environment variables of
-the style "FSSPEC_{protocol}_{kwargname}=value".
+the style ``FSSPEC_{protocol}_{kwargname}=value``.
 
 Configuration is determined in the following order, with later items winning:
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -98,7 +98,7 @@ PyArrow integration
     ``fsspec`` is only compatible with PyArrow's classic ``FileSystem``. Starting with version
     2.0 (released in October 2020), `pyarrow`_ switched to a C++ filesystem implementation that
     is no longer compatible with ``fsspec``. Please refer to 
-    `this GitHub issue https://github.com/intake/filesystem_spec/issues/295`_ for additional details.
+    `this GitHub issue <https://github.com/intake/filesystem_spec/issues/295>`_ for additional details.
 
 
 `pyarrow`_ has its own internal idea of what a file-system is (``pyarrow.filesystem.FileSystem``),


### PR DESCRIPTION
In the context of #295, it seems it will be non-trivial to seamlessly support pyarrow interoperability moving forward.

~It took me a bit of digging to realize why I couldn't easily interop between pyarrow and fsspec in my code base (I'm using pyarrow 4.0 but fsspec only supports pyarrow < 2.0). To this end, I added a small warning banner to the documentation to highlight this.~

fsspec no longer adds pyarrow superclasses to its fs files for pyarrow >= 2.0 since this is not necessary.

Made two other minor cosmetic fixes near my main change in `features.rst`.

**Testing plan:** I built the Sphinx docs on my machine and inspected my formatting changes visually, making sure that the new link works.

Let me know what you think!