### PR TITLE
Treat 0 as None for async timeout

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -97,11 +97,11 @@ PyArrow integration
 `pyarrow`_ has its own internal idea of what a file-system is (``pyarrow.fs.FileSystem``),
 and some functions, particularly the loading of parquet, require that the target be compatible.
 As it happens, the design of the file-system interface in ``pyarrow`` *is* compatible with ``fsspec``
-(this is not by accident). 
+(this is not by accident).
 
-At import time, ``fsspec`` checks for the existence of ``pyarrow``, and, if ``pyarrow < 2.0`` is 
+At import time, ``fsspec`` checks for the existence of ``pyarrow``, and, if ``pyarrow < 2.0`` is
 found, adds its base filesystem to the superclasses of the spec base-class.
-For ``pyarrow >= 2.0``, ``fsspec`` file systems can simply be passed to ``pyarrow`` functions 
+For ``pyarrow >= 2.0``, ``fsspec`` file systems can simply be passed to ``pyarrow`` functions
 that expect ``pyarrow`` filesystems, and ``pyarrow`` `will automatically wrap them
 <https://arrow.apache.org/docs/python/filesystems.html#using-fsspec-compatible-filesystems>`_.
 

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -14,6 +14,7 @@ private = re.compile("_[^_]")
 
 
 async def _runner(event, coro, result, timeout=None):
+    timeout = timeout if timeout else None  # convert 0 or 0.0 to None
     if timeout is not None:
         coro = asyncio.wait_for(coro, timeout=timeout)
     try:
@@ -34,6 +35,7 @@ def sync(loop, func, *args, timeout=None, **kwargs):
     """
     Make loop run coroutine until it returns. Runs in other thread
     """
+    timeout = timeout if timeout else None  # convert 0 or 0.0 to None
     # NB: if the loop is not running *yet*, it is OK to submit work
     # and we will wait for it
     if loop is None or loop.is_closed():

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -19,6 +19,8 @@ async def _runner(event, coro, result, timeout=None):
         coro = asyncio.wait_for(coro, timeout=timeout)
     try:
         result[0] = await coro
+    except asyncio.exceptions.TimeoutError:
+        result[0] = None
     except Exception as ex:
         result[0] = ex
     finally:

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -19,8 +19,6 @@ async def _runner(event, coro, result, timeout=None):
         coro = asyncio.wait_for(coro, timeout=timeout)
     try:
         result[0] = await coro
-    except asyncio.exceptions.TimeoutError:
-        result[0] = None
     except Exception as ex:
         result[0] = ex
     finally:

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -16,6 +16,42 @@ def test_sync_methods():
     assert not inspect.iscoroutinefunction(inst.info)
 
 
+class _DummyAsyncKlass:
+    def __init__(self):
+        self.loop = fsspec.asyn.get_loop()
+
+    async def _dummy_async_func(self):
+        # Sleep 1 second function to test timeout
+        await asyncio.sleep(1)
+        return True
+
+    dummy_func = fsspec.asyn.sync_wrapper(_dummy_async_func)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
+def test_sync_wrapper_timeout_on_less_than_expected_wait_time_not_finish_function():
+    test_obj = _DummyAsyncKlass()
+    assert test_obj.dummy_func(timeout=0.1) is None
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
+def test_sync_wrapper_timeout_on_more_than_expected_wait_time_will_finish_function():
+    test_obj = _DummyAsyncKlass()
+    assert test_obj.dummy_func(timeout=5)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
+def test_sync_wrapper_timeout_none_will_wait_func_finished():
+    test_obj = _DummyAsyncKlass()
+    assert test_obj.dummy_func(timeout=None)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
+def test_sync_wrapper_treat_timeout_0_as_none():
+    test_obj = _DummyAsyncKlass()
+    assert test_obj.dummy_func(timeout=0)
+
+
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
 def test_throttled_gather(monkeypatch):
     total_running = 0

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -28,10 +28,20 @@ class _DummyAsyncKlass:
     dummy_func = fsspec.asyn.sync_wrapper(_dummy_async_func)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
+@pytest.mark.skip(
+    reason="no way of handle the inconsistent behavior of the race condition on timeout"
+)
 def test_sync_wrapper_timeout_on_less_than_expected_wait_time_not_finish_function():
+    """
+    This test case is not able to execute because of the timeout race condition:
+     - It can timeout on asyncio.wait_for, which will raise exception TimeoutError
+     - It can timeout on threading.Event.wait, which will finish gracefully without
+       exception
+    Need a consistent result on timeout situation before complete the test case.
+    """
     test_obj = _DummyAsyncKlass()
-    assert test_obj.dummy_func(timeout=0.1) is None
+    with pytest.raises(asyncio.exceptions.TimeoutError):
+        test_obj.dummy_func(timeout=0.1)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")


### PR DESCRIPTION
In module asyn.py, when it get input argument timeout=0, it will wait for 0 second on async calls. To have 0 second timeout is kind of not make sense at all in an async situation (no waiting also means you can't finish anything), and on the other hand, use 0 second timeout to indicate infinite waiting is quite natural implementation.

This PR is for treat timeout=0 situation as timeout=None, which means for infinite timeout. This also align to some of the other storage client API (e.g. Azure Datalake).

Closes #642 