### PR TITLE
Raise FSTimeoutError on asyn timeout occurs

### DIFF
--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -10,6 +10,7 @@ except ImportError:  # python < 3.8
 from . import caching
 from ._version import get_versions
 from .core import get_fs_token_paths, open, open_files, open_local
+from .exceptions import FSBaseException, FSTimeoutError
 from .mapping import FSMap, get_mapper
 from .registry import (
     filesystem,
@@ -25,6 +26,8 @@ del get_versions
 
 __all__ = [
     "AbstractFileSystem",
+    "FSBaseException",
+    "FSTimeoutError",
     "FSMap",
     "filesystem",
     "register_implementation",

--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -10,7 +10,7 @@ except ImportError:  # python < 3.8
 from . import caching
 from ._version import get_versions
 from .core import get_fs_token_paths, open, open_files, open_local
-from .exceptions import FSBaseException, FSTimeoutError
+from .exceptions import FSTimeoutError
 from .mapping import FSMap, get_mapper
 from .registry import (
     filesystem,
@@ -26,7 +26,6 @@ del get_versions
 
 __all__ = [
     "AbstractFileSystem",
-    "FSBaseException",
     "FSTimeoutError",
     "FSMap",
     "filesystem",

--- a/fsspec/exceptions.py
+++ b/fsspec/exceptions.py
@@ -1,17 +1,10 @@
 """
 fsspec user-defined exception classes
 """
+import asyncio
 
 
-class FSBaseException(Exception):
-    """
-    Base exception for fsspec user-defined exceptions
-    """
-
-    ...
-
-
-class FSTimeoutError(FSBaseException):
+class FSTimeoutError(asyncio.TimeoutError):
     """
     Raised when a fsspec function timed out occurs
     """

--- a/fsspec/exceptions.py
+++ b/fsspec/exceptions.py
@@ -1,0 +1,19 @@
+"""
+fsspec user-defined exception classes
+"""
+
+
+class FSBaseException(Exception):
+    """
+    Base exception for fsspec user-defined exceptions
+    """
+
+    ...
+
+
+class FSTimeoutError(FSBaseException):
+    """
+    Raised when a fsspec function timed out occurs
+    """
+
+    ...

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -6,7 +6,6 @@ import pytest
 
 import fsspec
 import fsspec.asyn
-import fsspec.exceptions
 from fsspec.asyn import _throttled_gather
 
 
@@ -32,7 +31,7 @@ class _DummyAsyncKlass:
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
 def test_sync_wrapper_timeout_on_less_than_expected_wait_time_not_finish_function():
     test_obj = _DummyAsyncKlass()
-    with pytest.raises(fsspec.exceptions.FSTimeoutError):
+    with pytest.raises(fsspec.FSTimeoutError):
         test_obj.dummy_func(timeout=0.1)
 
 


### PR DESCRIPTION
Create fsspec's own user-defined exception type FSTimeoutError, raise FSTimeoutError in `asyn.sync` function when timeout occurs.
 
Closes #644 