### PR TITLE
optimisations

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -243,6 +243,9 @@ class AsyncFileSystem(AbstractFileSystem):
             *[self._pipe_file(k, v, **kwargs) for k, v in path.items()]
         )
 
+    async def _cat_file(self, path, start=None, end=None, **kwargs):
+        raise NotImplementedError
+
     async def _cat(self, path, recursive=False, on_error="raise", **kwargs):
         paths = await self._expand_path(path, recursive=recursive)
         out = await asyncio.gather(

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -121,7 +121,8 @@ class OpenFile(object):
         self.close()
 
     def __del__(self):
-        self.fobjects.clear()  # may cause cleanup of objects and close files
+        if hasattr(self, "fobjects"):
+            self.fobjects.clear()  # may cause cleanup of objects and close files
 
     def open(self):
         """Materialise this as a real open file without context

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -11,6 +11,7 @@ import aiohttp
 import requests
 
 from fsspec.asyn import AsyncFileSystem, sync, sync_wrapper
+from fsspec.exceptions import FSTimeoutError
 from fsspec.spec import AbstractBufferedFile
 from fsspec.utils import DEFAULT_BLOCK_SIZE, tokenize
 
@@ -104,7 +105,7 @@ class HTTPFileSystem(AsyncFileSystem):
             try:
                 sync(loop, session.close, timeout=0.1)
                 return
-            except TimeoutError:
+            except (TimeoutError, FSTimeoutError):
                 pass
         if session._connector is not None:
             # close after loop is dead

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -657,6 +657,9 @@ async def _file_size(url, session=None, size_policy="head", **kwargs):
     else:
         raise TypeError('size_policy must be "head" or "get", got %s' "" % size_policy)
     async with r:
+        # TODO:
+        #  recognise lack of 'Accept-Ranges', or  'Accept-Ranges': 'none' (not 'bytes')
+        #  to mean streaming only, no random access => return None
         if "Content-Length" in r.headers:
             return int(r.headers["Content-Length"])
         elif "Content-Range" in r.headers:

--- a/fsspec/implementations/jupyter.py
+++ b/fsspec/implementations/jupyter.py
@@ -59,7 +59,7 @@ class JupyterFileSystem(fsspec.AbstractFileSystem):
             return out
         return [o["name"] for o in out]
 
-    def cat_file(self, path):
+    def cat_file(self, path, start=None, end=None, **kwargs):
         path = self._strip_protocol(path)
         r = self.session.get(self.url + "/" + path)
         if r.status_code == 404:
@@ -68,9 +68,10 @@ class JupyterFileSystem(fsspec.AbstractFileSystem):
         out = r.json()
         if out["format"] == "text":
             # data should be binary
-            return out["content"].encode()
+            b = out["content"].encode()
         else:
-            return base64.b64decode(out["content"])
+            b = base64.b64decode(out["content"])
+        return b[start:end]
 
     def pipe_file(self, path, value, **_):
         path = self._strip_protocol(path)

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -174,12 +174,12 @@ def make_path_posix(path, sep=os.sep):
     """ Make path generic """
     if isinstance(path, (list, set, tuple)):
         return type(path)(make_path_posix(p) for p in path)
+    if "~" in path:
+        path = os.path.expanduser(path)
     if sep == "/":
         # most common fast case for posix
         if path.startswith("/"):
             return path
-        elif "~" in path:
-            return os.path.expanduser(path)
         return os.getcwd() + "/" + path
     if (
         (sep not in path and "/" not in path)

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -180,7 +180,7 @@ def make_path_posix(path, sep=os.sep):
     if (
         sep not in path
         and "/" not in path
-        or (sep == "/" and not path.startswith("/"))
+        or (not path.startswith("/"))
         or (sep == "\\" and ":" not in path)
     ):
         # relative path like "path" or "rel\\path" (win) or rel/path"

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -76,7 +76,7 @@ class LocalFileSystem(AbstractFileSystem):
                 t = "file"
             else:
                 t = "other"
-            path = path.path
+            path = self._strip_protocol(path.path)
         result = {
             "name": path,
             "size": out.st_size,
@@ -183,13 +183,13 @@ def make_path_posix(path, sep=os.sep):
         return os.getcwd() + "/" + path
     if (
         (sep not in path and "/" not in path)
-        or (not path.startswith("/"))
+        or (sep == "/" and not path.startswith("/"))
         or (sep == "\\" and ":" not in path and not path.startswith("\\\\"))
     ):
         # relative path like "path" or "rel\\path" (win) or rel/path"
         if os.sep == "\\":
             # abspath made some more '\\' separators
-            return make_path_posix(os.path.abspath(path), sep)
+            return make_path_posix(os.path.abspath(path))
         else:
             return os.getcwd() + "/" + path
     if re.match("/[A-Za-z]:", path):

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -182,10 +182,9 @@ def make_path_posix(path, sep=os.sep):
             return os.path.expanduser(path)
         return os.getcwd() + "/" + path
     if (
-        sep not in path
-        and "/" not in path
+        (sep not in path and "/" not in path)
         or (not path.startswith("/"))
-        or (sep == "\\" and ":" not in path)
+        or (sep == "\\" and ":" not in path and not path.startswith("\\\\"))
     ):
         # relative path like "path" or "rel\\path" (win) or rel/path"
         if os.sep == "\\":

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -5,7 +5,6 @@ import posixpath
 import re
 import shutil
 import tempfile
-from functools import lru_cache
 
 from fsspec import AbstractFileSystem
 from fsspec.utils import stringify_path
@@ -146,7 +145,6 @@ class LocalFileSystem(AbstractFileSystem):
             return cls.root_marker
 
     @classmethod
-    @lru_cache(100000)
     def _strip_protocol(cls, path):
         path = stringify_path(path)
         if path.startswith("file://"):
@@ -186,7 +184,7 @@ def make_path_posix(path, sep=os.sep):
         or (sep == "\\" and ":" not in path)
     ):
         # relative path like "path" or "rel\\path" (win) or rel/path"
-        path = os.path.abspath(path)
+        path = os.getcwd() + "/" + path
         if os.sep == "\\":
             # abspath made some more '\\' separators
             return make_path_posix(path, sep)

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -5,6 +5,7 @@ import posixpath
 import re
 import shutil
 import tempfile
+from functools import lru_cache
 
 from fsspec import AbstractFileSystem
 from fsspec.utils import stringify_path
@@ -145,6 +146,7 @@ class LocalFileSystem(AbstractFileSystem):
             return cls.root_marker
 
     @classmethod
+    @lru_cache(100000)
     def _strip_protocol(cls, path):
         path = stringify_path(path)
         if path.startswith("file://"):

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -184,10 +184,11 @@ def make_path_posix(path, sep=os.sep):
         or (sep == "\\" and ":" not in path)
     ):
         # relative path like "path" or "rel\\path" (win) or rel/path"
-        path = os.getcwd() + "/" + path
         if os.sep == "\\":
             # abspath made some more '\\' separators
-            return make_path_posix(path, sep)
+            return make_path_posix(os.path.abspath(path), sep)
+        else:
+            return os.getcwd() + "/" + path
     return path
 
 

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -152,9 +152,9 @@ class MemoryFileSystem(AbstractFileSystem):
         else:
             raise FileNotFoundError
 
-    def cat_file(self, path):
+    def cat_file(self, path, start=None, end=None, **kwargs):
         try:
-            return self.store[path].getvalue()
+            return self.store[path].getvalue()[start:end]
         except KeyError:
             raise FileNotFoundError(path)
 

--- a/fsspec/implementations/tests/test_hdfs.py
+++ b/fsspec/implementations/tests/test_hdfs.py
@@ -11,7 +11,7 @@ data = b"\n".join([b"some test data"] * 1000)
 @pytest.fixture
 def hdfs(request):
     try:
-        hdfs = pyarrow.hdfs.connect()
+        hdfs = pyarrow.hdfs.HadoopFileSystem()
     except IOError:
         pytest.skip("No HDFS configured")
 

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -150,6 +150,7 @@ def test_list_cache_with_expiry_time_purged(server):
     assert len(h.dircache) == 1
 
     # Verify cache content.
+    assert server + "/index/" in h.dircache
     assert len(h.dircache.get(server + "/index/")) == 1
 
     # Wait beyond the TTL / cache expiry time.

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -138,7 +138,7 @@ def test_list_cache_with_expiry_time_cached(server):
 
 
 def test_list_cache_with_expiry_time_purged(server):
-    h = fsspec.filesystem("http", use_listings_cache=True, listings_expiry_time=0.1)
+    h = fsspec.filesystem("http", use_listings_cache=True, listings_expiry_time=0.3)
 
     # First, the directory cache is not initialized.
     assert not h.dircache
@@ -150,11 +150,10 @@ def test_list_cache_with_expiry_time_purged(server):
     assert len(h.dircache) == 1
 
     # Verify cache content.
-    cached_items = h.dircache.get(server + "/index/")
-    assert len(cached_items) == 1
+    assert len(h.dircache.get(server + "/index/")) == 1
 
     # Wait beyond the TTL / cache expiry time.
-    time.sleep(0.2)
+    time.sleep(0.31)
 
     # Verify that the cache item should have been purged.
     cached_items = h.dircache.get(server + "/index/")

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -119,6 +119,26 @@ def test_urlpath_expand_read():
         assert len(paths) == 2
 
 
+def test_cats():
+    with filetexts(csv_files, mode="b"):
+        fs = fsspec.filesystem("file")
+        assert fs.cat(".test.fakedata.1.csv") == b"a,b\n" b"1,2\n"
+        out = set(fs.cat([".test.fakedata.1.csv", ".test.fakedata.2.csv"]).values())
+        assert out == {b"a,b\n" b"1,2\n", b"a,b\n" b"3,4\n"}
+        assert fs.cat(".test.fakedata.1.csv", None, None) == b"a,b\n" b"1,2\n"
+        assert fs.cat(".test.fakedata.1.csv", start=1, end=6) == b"a,b\n" b"1,2\n"[1:6]
+        assert fs.cat(".test.fakedata.1.csv", start=-1) == b"a,b\n" b"1,2\n"[-1:]
+        assert (
+            fs.cat(".test.fakedata.1.csv", start=1, end=-2) == b"a,b\n" b"1,2\n"[1:-2]
+        )
+        out = set(
+            fs.cat(
+                [".test.fakedata.1.csv", ".test.fakedata.2.csv"], start=1, end=-1
+            ).values()
+        )
+        assert out == {b"a,b\n" b"1,2\n"[1:-1], b"a,b\n" b"3,4\n"[1:-1]}
+
+
 def test_urlpath_expand_write():
     """Make sure * is expanded in file paths when writing."""
     _, _, paths = get_fs_token_paths("prefix-*.csv", mode="wb", num=2)
@@ -310,7 +330,7 @@ def test_globfind_dirs(tmpdir):
 def test_touch(tmpdir):
     import time
 
-    fn = tmpdir + "/in/file"
+    fn = str(tmpdir + "/in/file")
     fs = fsspec.filesystem("file", auto_mkdir=False)
     with pytest.raises(OSError):
         fs.touch(fn)
@@ -434,19 +454,21 @@ def test_make_path_posix():
     assert make_path_posix("rel/path", sep="/") == posixpath.join(
         make_path_posix(cwd), "rel/path"
     )
-    assert make_path_posix("C:\\path", sep="\\") == "C:/path"
-    assert (
-        make_path_posix(
-            "\\\\windows-server\\someshare\\path\\more\\path\\dir\\foo.parquet"
+    if WIN:
+        assert make_path_posix("C:\\path", sep="\\") == "C:/path"
+    if WIN:
+        assert (
+            make_path_posix(
+                "\\\\windows-server\\someshare\\path\\more\\path\\dir\\foo.parquet"
+            )
+            == "//windows-server/someshare/path/more/path/dir/foo.parquet"
         )
-        == "//windows-server/someshare/path/more/path/dir/foo.parquet"
-    )
-    assert (
-        make_path_posix(
-            r"\\SERVER\UserHomeFolder$\me\My Documents\project1\data\filen.csv"
+        assert (
+            make_path_posix(
+                r"\\SERVER\UserHomeFolder$\me\My Documents\project1\data\filen.csv"
+            )
+            == "//SERVER/UserHomeFolder$/me/My Documents/project1/data/filen.csv"
         )
-        == "//SERVER/UserHomeFolder$/me/My Documents/project1/data/filen.csv"
-    )
     assert "/" in make_path_posix("rel\\path", sep="\\")
 
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -448,14 +448,14 @@ def test_make_path_posix():
     else:
         assert make_path_posix("/a/posix/path") == "/a/posix/path"
         assert make_path_posix("/posix") == "/posix"
-    assert make_path_posix("relpath", sep="/") == posixpath.join(
+    assert make_path_posix("relpath") == posixpath.join(
         make_path_posix(cwd), "relpath"
     )
-    assert make_path_posix("rel/path", sep="/") == posixpath.join(
+    assert make_path_posix("rel/path") == posixpath.join(
         make_path_posix(cwd), "rel/path"
     )
     if WIN:
-        assert make_path_posix("C:\\path", sep="\\") == "C:/path"
+        assert make_path_posix("C:\\path") == "C:/path"
     if WIN:
         assert (
             make_path_posix(
@@ -469,7 +469,7 @@ def test_make_path_posix():
             )
             == "//SERVER/UserHomeFolder$/me/My Documents/project1/data/filen.csv"
         )
-    assert "/" in make_path_posix("rel\\path", sep="\\")
+    assert "/" in make_path_posix("rel\\path")
 
 
 def test_linked_files(tmpdir):

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -563,7 +563,7 @@ def test_pickle(tmpdir):
 
 
 def test_strip_protocol_expanduser():
-    path = "file://~\\foo\\bar" if sys.platform == "win32" else "file://~/foo/bar"
+    path = "file://~\\foo\\bar" if WIN else "file://~/foo/bar"
     stripped = LocalFileSystem._strip_protocol(path)
     assert path != stripped
     assert "file://" not in stripped

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -640,12 +640,27 @@ class AbstractFileSystem(up, metaclass=_Cached):
             return False
 
     def cat_file(self, path, start=None, end=None, **kwargs):
-        """ Get the content of a file """
+        """Get the content of a file
+
+        Parameters
+        ----------
+        path: URL of file on this filesystems
+        start, end: int
+            Bytes limits of the read. If negative, backwards from end,
+            like usual python slices. Either can be None for start or
+            end of file, respectively
+        kwargs: passed to ``open()``.
+        """
         # explicitly set buffering off?
         with self.open(path, "rb", **kwargs) as f:
             if start is not None:
-                f.seek(start)
+                if start >= 0:
+                    f.seek(start)
+                else:
+                    f.seek(start, 2)
             if end is not None:
+                if end < 0:
+                    end = f.size + end
                 return f.read(end - f.tell())
             return f.read()
 
@@ -705,7 +720,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
                         out[path] = e
             return out
         else:
-            return self.cat_file(paths[0])
+            return self.cat_file(paths[0], **kwargs)
 
     def get_file(self, rpath, lpath, **kwargs):
         """Copy single remote file to local"""

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -3,6 +3,7 @@ import logging
 import os
 import threading
 import warnings
+import weakref
 from distutils.version import LooseVersion
 from errno import ESPIPE
 from glob import has_magic
@@ -48,7 +49,7 @@ class _Cached(type):
         # Note: we intentionally create a reference here, to avoid garbage
         # collecting instances when all other references are gone. To really
         # delete a FileSystem, the cache must be cleared.
-        cls._cache = {}
+        cls._cache = weakref.WeakValueDictionary()
         cls._pid = os.getpid()
 
     def __call__(cls, *args, **kwargs):

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -233,6 +233,7 @@ def test_find_details():
 
 
 def test_cache():
+    import time
     fs = DummyTestFS()
     fs2 = DummyTestFS()
     assert fs is fs2
@@ -243,7 +244,11 @@ def test_cache():
     del fs
 
     # NEW: final del releases cached instance
-    assert len(DummyTestFS._cache) == 0
+    timeout = 3
+    while len(DummyTestFS._cache):
+        time.sleep(0.02)
+        timeout -= 0.02
+        assert timeout > 0
 
     DummyTestFS.clear_instance_cache()
     assert len(DummyTestFS._cache) == 0

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -233,7 +233,6 @@ def test_find_details():
 
 
 def test_cache():
-    import time
     fs = DummyTestFS()
     fs2 = DummyTestFS()
     assert fs is fs2
@@ -243,12 +242,8 @@ def test_cache():
     assert len(fs._cache) == 1
     del fs
 
-    # NEW: final del releases cached instance
-    timeout = 3
-    while len(DummyTestFS._cache):
-        time.sleep(0.02)
-        timeout -= 0.02
-        assert timeout > 0
+    # keeps and internal reference, doesn't get collected
+    assert len(DummyTestFS._cache) == 1
 
     DummyTestFS.clear_instance_cache()
     assert len(DummyTestFS._cache) == 0

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -241,7 +241,9 @@ def test_cache():
     del fs2
     assert len(fs._cache) == 1
     del fs
-    assert len(DummyTestFS._cache) == 1
+
+    # NEW: final del releases cached instance
+    assert len(DummyTestFS._cache) == 0
 
     DummyTestFS.clear_instance_cache()
     assert len(DummyTestFS._cache) == 0

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -303,7 +303,9 @@ def stringify_path(filepath):
     Any other object is passed through unchanged, which includes bytes,
     strings, buffers, or anything else that's not even path-like.
     """
-    if hasattr(filepath, "__fspath__"):
+    if isinstance(filepath, str):
+        return filepath
+    elif hasattr(filepath, "__fspath__"):
         return filepath.__fspath__()
     elif isinstance(filepath, pathlib.Path):
         return str(filepath)


### PR DESCRIPTION
- remove abspath from linux/mac make_path_posix and move fast-path to start of long function
- logging in fuse
- give option to don't have instance cache keep instances alive (but still share) using config "weakref_instance_cache"
- allow min/max to cat_file to be negative, like a slice