### PR TITLE
Add compression to LocalFileOpener

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -7,6 +7,8 @@ import shutil
 import tempfile
 
 from fsspec import AbstractFileSystem
+from fsspec.compression import compr
+from fsspec.core import get_compression
 from fsspec.utils import stringify_path
 
 
@@ -210,12 +212,13 @@ def make_path_posix(path, sep=os.sep):
 
 
 class LocalFileOpener(io.IOBase):
-    def __init__(self, path, mode, autocommit=True, fs=None, **kwargs):
+    def __init__(self, path, mode, autocommit=True, fs=None, compression=None, **kwargs):
         self.path = path
         self.mode = mode
         self.fs = fs
         self.f = None
         self.autocommit = autocommit
+        self.compression = get_compression(path, compression)
         self.blocksize = io.DEFAULT_BUFFER_SIZE
         self._open()
 
@@ -223,6 +226,9 @@ class LocalFileOpener(io.IOBase):
         if self.f is None or self.f.closed:
             if self.autocommit or "w" not in self.mode:
                 self.f = open(self.path, mode=self.mode)
+                if self.compression:
+                    compress = compr[self.compression]
+                    self.f = compress(self.f, mode=self.mode)
             else:
                 # TODO: check if path is writable?
                 i, name = tempfile.mkstemp()

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -212,7 +212,9 @@ def make_path_posix(path, sep=os.sep):
 
 
 class LocalFileOpener(io.IOBase):
-    def __init__(self, path, mode, autocommit=True, fs=None, compression=None, **kwargs):
+    def __init__(
+        self, path, mode, autocommit=True, fs=None, compression=None, **kwargs
+    ):
         self.path = path
         self.mode = mode
         self.fs = fs

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import gzip
+import bz2
 import os
 import os.path
 import pickle
@@ -659,6 +660,20 @@ def test_transaction(tmpdir):
             fp.write(content)
 
     with fs.open(file, "r") as fp:
+        read_content = fp.read()
+
+    assert content == read_content
+
+
+@pytest.mark.parametrize("opener, ext", [(bz2.open, "bz2"), (gzip.open, "gz")])
+def test_infer_compression(tmpdir, opener, ext):
+    filename = str(tmpdir / f"test.{ext}")
+    content = b"hello world"
+    with opener(filename, "wb") as fp:
+        fp.write(content)
+
+    fs = LocalFileSystem()
+    with fs.open(f"file://{filename}", "rb", compression="infer") as fp:
         read_content = fp.read()
 
     assert content == read_content

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -665,9 +665,9 @@ def test_transaction(tmpdir):
     assert content == read_content
 
 
-@pytest.mark.parametrize("opener, ext", [(bz2.open, "bz2"), (gzip.open, "gz")])
+@pytest.mark.parametrize("opener, ext", [(bz2.open, ".bz2"), (gzip.open, ".gz"), (open, "")])
 def test_infer_compression(tmpdir, opener, ext):
-    filename = str(tmpdir / f"test.{ext}")
+    filename = str(tmpdir / f"test{ext}")
     content = b"hello world"
     with opener(filename, "wb") as fp:
         fp.write(content)

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-import gzip
 import bz2
+import gzip
 import os
 import os.path
 import pickle
@@ -665,7 +665,9 @@ def test_transaction(tmpdir):
     assert content == read_content
 
 
-@pytest.mark.parametrize("opener, ext", [(bz2.open, ".bz2"), (gzip.open, ".gz"), (open, "")])
+@pytest.mark.parametrize(
+    "opener, ext", [(bz2.open, ".bz2"), (gzip.open, ".gz"), (open, "")]
+)
 def test_infer_compression(tmpdir, opener, ext):
     filename = str(tmpdir / f"test{ext}")
     content = b"hello world"


### PR DESCRIPTION
This PR copies the compression implementation from `OpenFile` to `LocalFileOpener` to allow the `compression` kwarg to work for local files again. 

I've added a simple test also. This should fix https://github.com/intake/filesystem_spec/issues/659