### PR TITLE
local: explicitly check for os.DirEntry

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -58,7 +58,7 @@ class LocalFileSystem(AbstractFileSystem):
         return super().glob(path, **kwargs)
 
     def info(self, path, **kwargs):
-        if hasattr(path, "stat"):
+        if isinstance(path, os.DirEntry):
             # scandir DirEntry
             out = path.stat(follow_symlinks=False)
             link = path.is_symlink()

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 from contextlib import contextmanager
 from distutils.version import LooseVersion
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -691,3 +692,12 @@ def test_infer_compression(tmpdir, opener, ext):
         read_content = fp.read()
 
     assert content == read_content
+
+
+def test_info_path_like(tmpdir):
+    path = Path(tmpdir / "test_info")
+    path.write_text("fsspec")
+
+    fs = LocalFileSystem()
+    assert fs.exists(path)
+    assert fs.info(path)["name"] == os.fspath(path)

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -700,4 +700,3 @@ def test_info_path_like(tmpdir):
 
     fs = LocalFileSystem()
     assert fs.exists(path)
-    assert fs.info(path)["name"] == os.fspath(path)


### PR DESCRIPTION
`pathlib.Path()` and some other variants also has `stat()` method though they shouldn't use that codepath (since it is specifically designated for `os.DirEntry`). I don't have the context on why it doesn't checking for this in the first place though I can verify it makes related tests pass on our side (downstream). Resolves #666 