### PR TITLE
avoid isfile calls on find as much as possible

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -581,7 +581,7 @@ class AsyncFileSystem(AbstractFileSystem):
             if withdirs:
                 files.update(dirs)
             out.update({info["name"]: info for name, info in files.items()})
-        if (await self._isfile(path)) and path not in out:
+        if not out and (await self._isfile(path)):
             # walk works on directories, but find should also return [path]
             # when path happens to be a file
             out[path] = {}

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -445,7 +445,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
             if withdirs:
                 files.update(dirs)
             out.update({info["name"]: info for name, info in files.items()})
-        if self.isfile(path) and path not in out:
+        if not out and self.isfile(path):
             # walk works on directories, but find should also return [path]
             # when path happens to be a file
             out[path] = {}

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -232,6 +232,14 @@ def test_find_details():
         assert details[filename] == test_fs.info(filename)
 
 
+def test_find_file():
+    test_fs = DummyTestFS()
+
+    filename = "misc/foo.txt"
+    assert test_fs.find(filename) == [filename]
+    assert test_fs.find(filename, detail=True) == {filename: {}}
+
+
 def test_cache():
     fs = DummyTestFS()
     fs2 = DummyTestFS()


### PR DESCRIPTION
In `find`, if `walk` also includes the `path` if it's a file, it should already be included in the `out`.
So, if `out` is not empty, we can safely assume that it is either a directory or a file. So, we don't need
to make an extra `isfile` call.

Though, if the path was an empty directory or if the walk does not return the file, we'll still be making an `isfile` call, which is unfortunate but better than before, where we were making an additional call for each find.

This was noticed in DVC when trying to migrate to WebdavFS, which was making remote cache querying noticeably slower when traversing through the caches.

Please let me know if I'm missing something here, or anything else that needs to be considered here. :)