### PR TITLE
LocalFileSystem.rm support for a sequence of string arguments

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -122,14 +122,18 @@ class LocalFileSystem(AbstractFileSystem):
         shutil.move(path1, path2)
 
     def rm(self, path, recursive=False, maxdepth=None):
-        path = self._strip_protocol(path).rstrip("/")
-        if recursive and self.isdir(path):
+        if isinstance(path, str):
+            path = [path]
 
-            if os.path.abspath(path) == os.getcwd():
-                raise ValueError("Cannot delete current working directory")
-            shutil.rmtree(path)
-        else:
-            os.remove(path)
+        for p in path:
+            p = self._strip_protocol(p).rstrip("/")
+            if recursive and self.isdir(p):
+
+                if os.path.abspath(p) == os.getcwd():
+                    raise ValueError("Cannot delete current working directory")
+                shutil.rmtree(p)
+            else:
+                os.remove(p)
 
     def _open(self, path, mode="rb", block_size=None, **kwargs):
         path = self._strip_protocol(path)
@@ -177,7 +181,7 @@ class LocalFileSystem(AbstractFileSystem):
 
 
 def make_path_posix(path, sep=os.sep):
-    """ Make path generic """
+    """Make path generic"""
     if isinstance(path, (list, set, tuple)):
         return type(path)(make_path_posix(p) for p in path)
     if "~" in path:

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -399,6 +399,11 @@ def test_file_ops(tmpdir):
     fs.rm(tmpdir + "/afile3", recursive=True)
     assert not fs.exists(tmpdir + "/afile3")
 
+    files = [tmpdir + "/afile4", tmpdir + "/afile5"]
+    [fs.touch(f) for f in files]
+    fs.rm(files)
+    assert all(not fs.exists(f) for f in files)
+
     fs.rm(tmpdir, recursive=True)
     assert not fs.exists(tmpdir)
 


### PR DESCRIPTION
`LocalFileSystem.rm(path)` now works if `path` is a sequence of strings. Resolves https://github.com/intake/filesystem_spec/issues/677 but not the deeper issue -- the tests in `test_mapping` are not parametrized over different filesystems, and so there is no general mechanism way to catch this kind of API mismatch.