### PR TITLE
Update entrypoint selection

### DIFF
--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -42,11 +42,15 @@ __all__ = [
 
 if entry_points is not None:
     try:
-        entry_points = entry_points()
+        eps = entry_points()
     except TypeError:
         pass  # importlib-metadata < 0.8
     else:
-        for spec in entry_points.get("fsspec.specs", []):
+        if hasattr(eps, "select"):  # Python 3.10+ / importlib_metadata >= 3.9.0
+            specs = eps.select(group="fsspec.specs")
+        else:
+            specs = eps.get("fsspec.specs", [])
+        for spec in specs:
             err_msg = f"Unable to load filesystem from {spec}"
             register_implementation(
                 spec.name, spec.value.replace(":", "."), errtxt=err_msg


### PR DESCRIPTION
Newer versions of Python and the `importlib_metadata` backport have deprecated `get(...)` in favor of `.select(...)`. This helps avoid the following warning (xref [this CI build](https://github.com/intake/filesystem_spec/runs/2863049046))

```
 fsspec/__init__.py:49
  /home/runner/work/filesystem_spec/filesystem_spec/fsspec/__init__.py:49: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for spec in entry_points.get("fsspec.specs", []):
```