### PR TITLE
Fix test_unmodel to accept ujson encoding without whitespace

### DIFF
--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -104,7 +104,8 @@ jdata = """{
 
 def test_unmodel():
     refs = _unmodel_hdf5(json.loads(jdata))
-    assert b'"Conventions": "UGRID-0.9.0"' in refs[".zattrs"]
+    # apparently the output may or may not contain a space after ":"
+    assert b'"Conventions":"UGRID-0.9.0"' in refs[".zattrs"].replace(b" ", b"")
     assert refs["adcirc_mesh/0"] == ("https://url", 8928, 8932)
 
 


### PR DESCRIPTION
The ujson encoding for test_unmodel data is b'"Conventions":"UGRID-0.9.0"'
(without a space after ':') that breaks the test for me.  Update
the test to make the whitespace optional.

That said, I have tried multiple ujson versions, going back to <3,
and was not able to reproduce the output with space.