### PR TITLE
Use isal if present to decompress .gz files

### DIFF
--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -73,6 +73,11 @@ register_compression("bz2", BZ2File, "bz2")
 try:
     from isal import igzip
 
+    # igzip is meant to be used as a faster drop in replacement to gzip
+    # so its api and functions are the same as the stdlib’s module. Except
+    # where ISA-L does not support the same calls as zlib
+    # (See https://python-isal.readthedocs.io/).
+
     register_compression("gzip", igzip.IGzipFile, "gz")
 except ImportError:
     from gzip import GzipFile

--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -1,6 +1,5 @@
 """Helper functions for a standard streaming compression API"""
 from bz2 import BZ2File
-from gzip import GzipFile
 from zipfile import ZipFile
 
 import fsspec.utils
@@ -70,7 +69,17 @@ def unzip(infile, mode="rb", filename=None, **kwargs):
 
 register_compression("zip", unzip, "zip")
 register_compression("bz2", BZ2File, "bz2")
-register_compression("gzip", lambda f, **kwargs: GzipFile(fileobj=f, **kwargs), "gz")
+
+try:
+    from isal import igzip
+
+    register_compression("gzip", igzip.IGzipFile, "gz")
+except ImportError:
+    from gzip import GzipFile
+    
+    register_compression(
+        "gzip", lambda f, **kwargs: GzipFile(fileobj=f, **kwargs), "gz"
+    )
 
 try:
     from lzma import LZMAFile

--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -76,7 +76,7 @@ try:
     register_compression("gzip", igzip.IGzipFile, "gz")
 except ImportError:
     from gzip import GzipFile
-    
+
     register_compression(
         "gzip", lambda f, **kwargs: GzipFile(fileobj=f, **kwargs), "gz"
     )

--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -70,7 +70,7 @@ def unzip(infile, mode="rb", filename=None, **kwargs):
 register_compression("zip", unzip, "zip")
 register_compression("bz2", BZ2File, "bz2")
 
-try:
+try:  # pragma: no cover
     from isal import igzip
 
     # igzip is meant to be used as a faster drop in replacement to gzip


### PR DESCRIPTION
Hello,

[python-isal](https://python-isal.readthedocs.io/en/stable/index.html#) offers a faster (~25-30%) gzip compression & decompression.

This PR proposes to use python-isal if present instead of the gzip module