### PR TITLE
Removed unecessary call to `jinja2.Template.render()` in Reference.py

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -284,7 +284,6 @@ class ReferenceFileSystem(AsyncFileSystem):
             else:
                 u = v[0]
                 if "{{" in u:
-                    u = jinja2.Template(u).render(**self.templates)
                     if self.simple_templates:
                         u = (
                             u.replace("{{", "{")

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -272,8 +272,6 @@ class ReferenceFileSystem(AsyncFileSystem):
 
         @lru_cache(1000)
         def _render_jinja(u):
-            import jinja2
-
             return jinja2.Template(u).render(**self.templates)
 
         for k, v in references.get("refs", {}).items():


### PR DESCRIPTION
Based on working through an issue with @martindurant in https://github.com/intake/fsspec-reference-maker/pull/33

jinja2 was slowing down my code and specifying `simple_templates=True` to `fsspec.filesystem()` was not bypassing jinja2, as it should have. This line is to blame