### PR TITLE
check for bytes return type and dictifiy it

### DIFF
--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -88,6 +88,8 @@ class FSMap(MutableMapping):
         oe = on_error if on_error == "raise" else "return"
         try:
             out = self.fs.cat(keys2, on_error=oe)
+            if isinstance(out, bytes):
+                out = {keys2[0]: out}
         except self.missing_exceptions as e:
             raise KeyError from e
         out = {


### PR DESCRIPTION
Fixes #707

`self.fs.cat` returns an instance of `bytes` if `keys2` has one element, which causes an error when `fsmap.getitems` attempts to access the `items` property of that value. This PR checks if `self.fs.cat` returned an instance of `bytes`, and if so, sticks it in a dict. This kind of problem might be an argument for type annotations, which would have flagged this issue earlier.