### PR TITLE
tiny bugfix to WholeFileCacheFileSystem.cat

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -572,8 +572,8 @@ class WholeFileCacheFileSystem(CachingFileSystem):
 
         out = {}
         callback.set_size(len(paths))
-        for path, fn in zip(paths, fns):
-            out[path] = open(fn, "rb").read()
+        for p, fn in zip(paths, fns):
+            out[p] = open(fn, "rb").read()
             callback.relative_update(1)
         if isinstance(path, str) and len(paths) == 1 and recursive is False:
             out = out[paths[0]]


### PR DESCRIPTION
Variable `path` defined in the for loop shadows the argument `path` of the `cat` method. Even if the original argument `path` is a list, after the for loop, the path has become a `str`. This affects the `isinstance(path, str)` check below, changing the behavior of the method.

This PR fixes this by renaming the variable used in the for loop.