### PR TITLE
Support datetime64 and timedelta64

### DIFF
--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -178,9 +178,10 @@ class FSMap(MutableMapping):
 def maybe_convert(value):
     if isinstance(value, array.array) or hasattr(value, "__array__"):
         # bytes-like things
-        if hasattr(value, "dtype") and value.dtype.kind in ["M", "m"]:
-            # numpy datetime64/timedelta64
-            value = value.view("i8")
+        if hasattr(value, "dtype") and value.dtype.kind in "Mm":
+            # The buffer interface doesn't support datetime64/timdelta64 numpy
+            # arrays
+            value = value.view("int64")
         value = bytearray(memoryview(value))
     return value
 

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -178,6 +178,9 @@ class FSMap(MutableMapping):
 def maybe_convert(value):
     if isinstance(value, array.array) or hasattr(value, "__array__"):
         # bytes-like things
+        if hasattr(value, "dtype") and value.dtype.kind in ["M", "m"]:
+            # numpy datetime64/timedelta64
+            value = value.view("i8")
         value = bytearray(memoryview(value))
     return value
 

--- a/fsspec/tests/test_mapping.py
+++ b/fsspec/tests/test_mapping.py
@@ -119,3 +119,27 @@ def test_setitem_numpy():
     assert m["c"] == b"\x01\x00\x00\x00"
     m["c"] = np.array([1, 2], dtype="<i4")  # array
     assert m["c"] == b"\x01\x00\x00\x00\x02\x00\x00\x00"
+    m["c"] = np.array(
+        np.datetime64("2000-01-01T23:59:59.999999999"), dtype="<M8[ns]"
+    )  # datetime64 scalar
+    assert m["c"] == b"\xff\xff\x91\xe3c\x9b#\r"
+    m["c"] = np.array(
+        [
+            np.datetime64("1900-01-01T23:59:59.999999999"),
+            np.datetime64("2000-01-01T23:59:59.999999999"),
+        ],
+        dtype="<M8[ns]",
+    )  # datetime64 array
+    assert m["c"] == b"\xff\xff}p\xf8fX\xe1\xff\xff\x91\xe3c\x9b#\r"
+    m["c"] = np.array(
+        np.timedelta64(3155673612345678901, "ns"), dtype="<m8[ns]"
+    )  # timedelta64 scalar
+    assert m["c"] == b"5\x1c\xf0Rn4\xcb+"
+    m["c"] = np.array(
+        [
+            np.timedelta64(450810516049382700, "ns"),
+            np.timedelta64(3155673612345678901, "ns"),
+        ],
+        dtype="<m8[ns]",
+    )  # timedelta64 scalar
+    assert m["c"] == b',M"\x9e\xc6\x99A\x065\x1c\xf0Rn4\xcb+'


### PR DESCRIPTION
Creating a Zarr array using datetime64 without compression and filters does not work. The function [maybe_convert](https://github.com/fbriol/filesystem_spec/blob/ce7c23babf5d87099a9171463bc8e74570b23f19/fsspec/mapping.py#L178)  transforming the array into a byte array []() has issues because it cannot handle the numpy data types 'M' (numpy.datetime64) and 'm' (numpy.timedelta64).

The following code, throw a ValeurError exception with the message `cannot include dtype 'M' in a buffer`

```python
import numpy
import dask.array
import fsspec
import zarr

start_date = numpy.datetime64("2000-01-01", "us")
end_date = numpy.datetime64("2001-12-31", "us")
delta = numpy.timedelta64(1, "h")

dates = numpy.arange(start_date, end_date, delta)

array = dask.array.from_array(dates)
fs = fsspec.filesystem("memory")
mapper = fs.get_mapper("/tmp/array.zarr")

zarray = dask.delayed(zarr.create)(shape=dates.shape,
                                   compressor=None,
                                   dtype=dates.dtype,
                                   store=mapper,
                                   overwrite=True)
array.store(zarray, lock=False, compute=True, return_stored=False)
```
This pull request corrects this problem.