### PR TITLE
Correct `self.fs.ftp._connect()` -> `self.fs._connect()` in ftp.py

### DIFF
--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -310,7 +310,7 @@ class FTPFile(AbstractBufferedFile):
                 self.fs.ftp.abort()
                 self.fs.ftp.getmultiline()
             except Error:
-                self.fs.ftp._connect()
+                self.fs._connect()
 
         return b"".join(out)
 


### PR DESCRIPTION
This PR makes the correction initially identified by @martindurant in https://github.com/intake/filesystem_spec/issues/641#issuecomment-842747716

It will be useful so that the correct `ftplib` error type(s) can be caught downstream try/except blocks.