### PR TITLE
isdir to give false when http url does not exist

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -472,7 +472,10 @@ class HTTPFileSystem(AsyncFileSystem):
 
     async def _isdir(self, path):
         # override, since all URLs are (also) files
-        return bool(await self._ls(path))
+        try:
+            return bool(await self._ls(path))
+        except (FileNotFoundError, ValueError):
+            return False
 
 
 class HTTPFile(AbstractBufferedFile):

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -276,6 +276,7 @@ def test_isdir(server):
     h = fsspec.filesystem("http")
     assert h.isdir(server + "/index/")
     assert not h.isdir(server + "/index/realfile")
+    assert not h.isdir(server + "doesnotevenexist")
 
 
 def test_policy_arg(server):


### PR DESCRIPTION
@tdhopper I think this was the fix you were after. Here is the s3 counterpart: https://github.com/dask/s3fs/pull/522 (already released).