### PR TITLE
fsspec/implementations/local: correctly report seekable

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -315,6 +315,9 @@ class LocalFileOpener(io.IOBase):
     def seek(self, *args, **kwargs):
         return self.f.seek(*args, **kwargs)
 
+    def seekable(self, *args, **kwargs):
+        return self.f.seekable(*args, **kwargs)
+
     def readline(self, *args, **kwargs):
         return self.f.readline(*args, **kwargs)
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -724,3 +724,18 @@ def test_info_path_like(tmpdir):
 
     fs = LocalFileSystem()
     assert fs.exists(path)
+
+
+def test_seekable(tmpdir):
+    fs = LocalFileSystem()
+    tmpdir = str(tmpdir)
+    fn0 = os.path.join(tmpdir, "target")
+
+    with open(fn0, "wb") as f:
+        f.write(b"data")
+
+    f = fs.open(fn0, "rt")
+    assert f.seekable(), "file is not seekable"
+    f.seek(1)
+    assert f.read(1) == "a"
+    assert f.tell() == 2

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -138,3 +138,15 @@ def test_rm_reursive_empty_subdir(m):
     m.mkdir("recdir/subdir2")
     m.rm("recdir/", recursive=True)
     assert not m.exists("dir")
+
+
+def test_seekable(m):
+    fn0 = "foo.txt"
+    with m.open(fn0, "wb") as f:
+        f.write(b"data")
+
+    f = m.open(fn0, "rt")
+    assert f.seekable(), "file is not seekable"
+    f.seek(1)
+    assert f.read(1) == "a"
+    assert f.tell() == 2


### PR DESCRIPTION
The current implementation of the local filesystem throws an error when you try to seek on a text file opened in text mode. This is because `io.TextIOWrapper` checks seekable() before calling seek/tell even though it is supported.

This adds the `.seekable()` method so seeking can be used in text mode where supported.

This also adds a local and in-memory FS test just for good measure.