### PR TITLE
http: allow put_file()ing file-like objects

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -255,8 +255,8 @@ class HTTPFileSystem(AsyncFileSystem):
 
     async def _put_file(
         self,
-        rpath,
         lpath,
+        rpath,
         chunk_size=5 * 2 ** 20,
         callback=_DEFAULT_CALLBACK,
         method="post",
@@ -265,11 +265,11 @@ class HTTPFileSystem(AsyncFileSystem):
         async def gen_chunks():
             # Support passing arbitrary file-like objects
             # and use them instead of streams.
-            if isinstance(rpath, io.IOBase):
-                context = nullcontext(rpath)
+            if isinstance(lpath, io.IOBase):
+                context = nullcontext(lpath)
                 use_seek = False  # might not support seeking
             else:
-                context = open(rpath, "rb")
+                context = open(lpath, "rb")
                 use_seek = True
 
             with context as f:
@@ -294,8 +294,8 @@ class HTTPFileSystem(AsyncFileSystem):
             )
 
         meth = getattr(session, method)
-        async with meth(lpath, data=gen_chunks(), **kw) as resp:
-            self._raise_not_found_for_status(resp, lpath)
+        async with meth(rpath, data=gen_chunks(), **kw) as resp:
+            self._raise_not_found_for_status(resp, rpath)
 
     async def _exists(self, path, **kwargs):
         kw = self.kwargs.copy()

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -276,6 +276,8 @@ class HTTPFileSystem(AsyncFileSystem):
                 if use_seek:
                     callback.set_size(f.seek(0, 2))
                     f.seek(0)
+                else:
+                    callback.set_size(getattr(f, "size"))
 
                 chunk = f.read(64 * 1024)
                 while chunk:

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -277,7 +277,7 @@ class HTTPFileSystem(AsyncFileSystem):
                     callback.set_size(f.seek(0, 2))
                     f.seek(0)
                 else:
-                    callback.set_size(getattr(f, "size"))
+                    callback.set_size(getattr(f, "size", None))
 
                 chunk = f.read(64 * 1024)
                 while chunk:

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -232,21 +232,21 @@ class HTTPFileSystem(AsyncFileSystem):
         return out
 
     async def _get_file(
-        self, lpath, rpath, chunk_size=5 * 2 ** 20, callback=_DEFAULT_CALLBACK, **kwargs
+        self, rpath, lpath, chunk_size=5 * 2 ** 20, callback=_DEFAULT_CALLBACK, **kwargs
     ):
         kw = self.kwargs.copy()
         kw.update(kwargs)
-        logger.debug(lpath)
+        logger.debug(rpath)
         session = await self.set_session()
-        async with session.get(lpath, **self.kwargs) as r:
+        async with session.get(rpath, **self.kwargs) as r:
             try:
                 size = int(r.headers["content-length"])
             except (ValueError, KeyError):
                 size = None
 
             callback.set_size(size)
-            self._raise_not_found_for_status(r, lpath)
-            with open(rpath, "wb") as fd:
+            self._raise_not_found_for_status(r, rpath)
+            with open(lpath, "wb") as fd:
                 chunk = True
                 while chunk:
                     chunk = await r.content.read(chunk_size)

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -232,21 +232,21 @@ class HTTPFileSystem(AsyncFileSystem):
         return out
 
     async def _get_file(
-        self, rpath, lpath, chunk_size=5 * 2 ** 20, callback=_DEFAULT_CALLBACK, **kwargs
+        self, lpath, rpath, chunk_size=5 * 2 ** 20, callback=_DEFAULT_CALLBACK, **kwargs
     ):
         kw = self.kwargs.copy()
         kw.update(kwargs)
-        logger.debug(rpath)
+        logger.debug(lpath)
         session = await self.set_session()
-        async with session.get(rpath, **self.kwargs) as r:
+        async with session.get(lpath, **self.kwargs) as r:
             try:
                 size = int(r.headers["content-length"])
             except (ValueError, KeyError):
                 size = None
 
             callback.set_size(size)
-            self._raise_not_found_for_status(r, rpath)
-            with open(lpath, "wb") as fd:
+            self._raise_not_found_for_status(r, lpath)
+            with open(rpath, "wb") as fd:
                 chunk = True
                 while chunk:
                     chunk = await r.content.read(chunk_size)

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -472,7 +472,7 @@ def test_put_file(server, tmp_path, method, reset_files):
     assert fs.cat(server + "/hey_2") == b"xxx"
 
     fs.put_file(io.BytesIO(b"yyy"), server + "/hey_3", method=method)
-    assert fs.cat(server + "/hey_3") == b"xxx"
+    assert fs.cat(server + "/hey_3") == b"yyy"
 
 
 @pytest.mark.xfail(

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -465,6 +465,11 @@ def test_put_file(server, tmp_path, method, reset_files):
     fs.get_file(server + "/hey", dwl_file)
     assert dwl_file.read_bytes() == data
 
+    src_file.write_bytes(b"xxx")
+    with open(src_file, "rb") as stream:
+        fs.put_file(stream, server + "/hey_2", method=method)
+    assert fs.cat(server + "/hey_2") == b"xxx"
+
 
 @pytest.mark.xfail(
     condition=sys.flags.optimize > 1, reason="no docstrings when optimised"

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import io
 import os
 import sys
 import threading
@@ -469,6 +470,9 @@ def test_put_file(server, tmp_path, method, reset_files):
     with open(src_file, "rb") as stream:
         fs.put_file(stream, server + "/hey_2", method=method)
     assert fs.cat(server + "/hey_2") == b"xxx"
+
+    fs.put_file(io.BytesIO(b"yyy"), server + "/hey_3", method=method)
+    assert fs.cat(server + "/hey_3") == b"xxx"
 
 
 @pytest.mark.xfail(

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -469,10 +469,6 @@ def mirror_from(origin_name, methods):
     return wrapper
 
 
-try:
-    from contextlib import nullcontext
-except ImportError:
-
-    @contextmanager
-    def nullcontext(obj=None):
-        yield obj
+@contextmanager
+def nullcontext(obj):
+    yield obj

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import re
 import sys
+from contextlib import contextmanager
 from functools import partial
 from hashlib import md5
 from urllib.parse import urlsplit
@@ -466,3 +467,12 @@ def mirror_from(origin_name, methods):
         return cls
 
     return wrapper
+
+
+try:
+    from contextlib import nullcontext
+except ImportError:
+
+    @contextmanager
+    def nullcontext(obj=None):
+        yield obj


### PR DESCRIPTION
Since writing to `HTTPFile` is not supported, currently you can not upload arbitrary streams (unlike other filesystems where you could open a new file in writing mode through `fs.open(path, 'wb')` and copy the original stream through `shutil.copy_file_obj()` to the new file). Not sure if this would be worth documenting at the moment, but would be extremely useful to compensate for the missing `w` method at the moment while we are thinking about other solutions.