### PR TITLE
Declare more extras; fix various Sphinx warnings

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -13,3 +13,5 @@ dependencies:
   - pyarrow=1
   - libarchive
   - smbprotocol
+  - python-libarchive-c
+  - panel

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -126,7 +126,7 @@ Built-in Implementations
 .. autoclass:: fsspec.implementations.hdfs.PyArrowHDFS
    :members: __init__
 
-.. autoclass:: fsspec.implementations.hdfs.ArrowFSWrapper
+.. autoclass:: fsspec.implementations.arrow.ArrowFSWrapper
    :members: __init__
 
 .. autoclass:: fsspec.implementations.hdfs.HadoopFileSystem

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,6 +85,9 @@ pygments_style = "sphinx"
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+default_role = "py:obj"
+autodoc_mock_imports = ["fuse"]
+
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -143,7 +143,7 @@ is a harder problem to solve, and the implementation described here is only part
 Mount anything with FUSE
 ------------------------
 
-Any path of any file-system can be mapped to a local directory using pyfuse and
+Any path of any file-system can be mapped to a local directory using `fusepy <https://pypi.org/project/fusepy/>`_ and
 :func:`fsspec.fuse.run`. This feature is experimental, but basic file listing with
 details, and read/write should generally be available to the extent that the
 remote file-system provides enough information. Naturally, if a file-system is read-only,

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -168,8 +168,8 @@ is currently a simple dict, but could in the future be LRU, or something more co
 to fine-tune instance lifetimes.
 
 Since files can hold on to write caches and read buffers,
-the instance cache may cause excessive memory usage in some situations; but normally, files
-will get ``close``\d, and the data discarded. Only when there is also an unfinalised transaction or
+the instance cache may cause excessive memory usage in some situations; but normally, files'
+``close`` methods will be called, discarding the data. Only when there is also an unfinalised transaction or
 captured traceback might this be anticipated becoming a problem.
 
 To disable instance caching, i.e., get a fresh instance which is not in the cache

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -169,7 +169,7 @@ to fine-tune instance lifetimes.
 
 Since files can hold on to write caches and read buffers,
 the instance cache may cause excessive memory usage in some situations; but normally, files
-will get ``close``d, and the data discarded. Only when there is also an unfinalised transaction or
+will get ``close``\d, and the data discarded. Only when there is also an unfinalised transaction or
 captured traceback might this be anticipated becoming a problem.
 
 To disable instance caching, i.e., get a fresh instance which is not in the cache
@@ -337,7 +337,7 @@ config files, providing environment variables, or editing the contents of
 the dictionary ``fsspec.config.conf``.
 
 Files are stored in the directory pointed to by ``FSSPEC_CONFIG_DIR``,
-``"~/.config/fsspec/`` by default. All *.ini and *.json files will be
+``"~/.config/fsspec/`` by default. All \*.ini and \*.json files will be
 loaded and parsed from their respective formats and fed into the config dict
 at import time. For example, if there is a file "~/.config/fsspec/conf.json"
 containing

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
 ``fsspec``: Filesystem interfaces for Python
-======================================
+============================================
 
 Filesystem Spec (``fsspec``) is a project to provide a unified pythonic interface to
 local, remote and embedded file systems and bytes storage.
@@ -25,7 +25,7 @@ storage systems; and top-level convenience functions like :func:`fsspec.open`, t
 you to quickly get from a URL to a file-like object that you can use with a third-party
 library or your own code.
 
-The section :doc:`background` gives motivation and history of this project, but
+The section :doc:`intro` gives motivation and history of this project, but
 most users will want to skip straight to :doc:`usage` to find out how to use
 the package and :doc:`features` to see the long list of added functionality
 included along with the basic file-system interface.

--- a/fsspec/callbacks.py
+++ b/fsspec/callbacks.py
@@ -16,7 +16,7 @@ class Callback:
         Starting internal counter value
     hooks: dict or None
         A dict of named functions to be called on each update. The signature
-        of these must be f(size, value, **kwargs)
+        of these must be ``f(size, value, **kwargs)``
     """
 
     def __init__(self, size=None, value=0, hooks=None, **kwargs):
@@ -89,7 +89,8 @@ class Callback:
             hook(self.size, self.value, **kw)
 
     def wrap(self, iterable):
-        """Wrap an iterable to call ``relative_update`` on each iterations
+        """
+        Wrap an iterable to call ``relative_update`` on each iterations
 
         Parameters
         ----------

--- a/fsspec/dircache.py
+++ b/fsspec/dircache.py
@@ -5,20 +5,20 @@ from functools import lru_cache
 
 class DirCache(MutableMapping):
     """
-    Caching of directory listings, in a structure like
+    Caching of directory listings, in a structure like::
 
-    {"path0": [
-        {"name": "path0/file0",
-         "size": 123,
-         "type": "file",
-         ...
-        },
-        {"name": "path0/file1",
-        },
-        ...
-        ],
-     "path1": [...]
-    }
+        {"path0": [
+            {"name": "path0/file0",
+             "size": 123,
+             "type": "file",
+             ...
+            },
+            {"name": "path0/file1",
+            },
+            ...
+            ],
+         "path1": [...]
+        }
 
     Parameters to this class control listing expiry or indeed turn
     caching off

--- a/fsspec/implementations/smb.py
+++ b/fsspec/implementations/smb.py
@@ -21,9 +21,10 @@ class SMBFileSystem(AbstractFileSystem):
 
     When using `fsspec.open()` for getting a file-like object the URI
     should be specified as this format:
-    `smb://workgroup;user:password@server:port/share/folder/file.csv`.
+    ``smb://workgroup;user:password@server:port/share/folder/file.csv``.
 
     Example::
+
         >>> import fsspec
         >>> with fsspec.open(
         ...     'smb://myuser:mypassword@myserver.com/' 'share/folder/file.csv'
@@ -37,7 +38,7 @@ class SMBFileSystem(AbstractFileSystem):
     The first component of the path in the URL points to the name of the shared
     folder. Subsequent path components will point to the directory/folder/file.
 
-    The URL components `workgroup` , `user`, `password` and `port` may be
+    The URL components ``workgroup`` , ``user``, ``password`` and ``port`` may be
     optional.
 
     .. note::
@@ -96,10 +97,11 @@ class SMBFileSystem(AbstractFileSystem):
             performed with this file system object.
             This affects whether other processes can concurrently open a handle
             to the same file.
-              None (the default): exclusively locks the file until closed.
-              'r': Allow other handles to be opened with read access.
-              'w': Allow other handles to be opened with write access.
-              'd': Allow other handles to be opened with delete access.
+
+            - None (the default): exclusively locks the file until closed.
+            - 'r': Allow other handles to be opened with read access.
+            - 'w': Allow other handles to be opened with write access.
+            - 'd': Allow other handles to be opened with delete access.
         """
         super(SMBFileSystem, self).__init__(**kwargs)
         self.host = host

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -71,7 +71,7 @@ class WebHDFS(AbstractFileSystem):
             the user in who's name actions are taken
         kerb_kwargs: dict
             Any extra arguments for HTTPKerberosAuth, see
-            https://github.com/requests/requests-kerberos/blob/master/requests_kerberos/kerberos_.py
+            `<https://github.com/requests/requests-kerberos/blob/master/requests_kerberos/kerberos_.py>`_
         data_proxy: dict, callable or None
             If given, map data-node addresses. This can be necessary if the
             HDFS cluster is behind a proxy, running on Docker or otherwise has

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -684,6 +684,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
         """Put value into path
 
         (counterpart to ``cat``)
+
         Parameters
         ----------
         path: string or dict(str, bytes)
@@ -1178,47 +1179,47 @@ class AbstractFileSystem(up, metaclass=_Cached):
     # Aliases
 
     def makedir(self, path, create_parents=True, **kwargs):
-        """Alias of :ref:`FilesystemSpec.mkdir`."""
+        """Alias of `AbstractFileSystem.mkdir`."""
         return self.mkdir(path, create_parents=create_parents, **kwargs)
 
     def mkdirs(self, path, exist_ok=False):
-        """Alias of :ref:`FilesystemSpec.makedirs`."""
+        """Alias of `AbstractFileSystem.makedirs`."""
         return self.makedirs(path, exist_ok=exist_ok)
 
     def listdir(self, path, detail=True, **kwargs):
-        """Alias of :ref:`FilesystemSpec.ls`."""
+        """Alias of `AbstractFileSystem.ls`."""
         return self.ls(path, detail=detail, **kwargs)
 
     def cp(self, path1, path2, **kwargs):
-        """Alias of :ref:`FilesystemSpec.copy`."""
+        """Alias of `AbstractFileSystem.copy`."""
         return self.copy(path1, path2, **kwargs)
 
     def move(self, path1, path2, **kwargs):
-        """Alias of :ref:`FilesystemSpec.mv`."""
+        """Alias of `AbstractFileSystem.mv`."""
         return self.mv(path1, path2, **kwargs)
 
     def stat(self, path, **kwargs):
-        """Alias of :ref:`FilesystemSpec.info`."""
+        """Alias of `AbstractFileSystem.info`."""
         return self.info(path, **kwargs)
 
     def disk_usage(self, path, total=True, maxdepth=None, **kwargs):
-        """Alias of :ref:`FilesystemSpec.du`."""
+        """Alias of `AbstractFileSystem.du`."""
         return self.du(path, total=total, maxdepth=maxdepth, **kwargs)
 
     def rename(self, path1, path2, **kwargs):
-        """Alias of :ref:`FilesystemSpec.mv`."""
+        """Alias of `AbstractFileSystem.mv`."""
         return self.mv(path1, path2, **kwargs)
 
     def delete(self, path, recursive=False, maxdepth=None):
-        """Alias of :ref:`FilesystemSpec.rm`."""
+        """Alias of `AbstractFileSystem.rm`."""
         return self.rm(path, recursive=recursive, maxdepth=maxdepth)
 
     def upload(self, lpath, rpath, recursive=False, **kwargs):
-        """Alias of :ref:`FilesystemSpec.put`."""
+        """Alias of `AbstractFileSystem.put`."""
         return self.put(lpath, rpath, recursive=recursive, **kwargs)
 
     def download(self, rpath, lpath, recursive=False, **kwargs):
-        """Alias of :ref:`FilesystemSpec.get`."""
+        """Alias of `AbstractFileSystem.get`."""
         return self.get(rpath, lpath, recursive=recursive, **kwargs)
 
     def sign(self, path, expiration=100, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "oci": ["ocifs"],
         "smb": ["smbprotocol"],
         "ssh": ["paramiko"],
+        "fuse": ["fusepy"],
     },
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ setup(
         "smb": ["smbprotocol"],
         "ssh": ["paramiko"],
         "fuse": ["fusepy"],
+        "libarchive": ["libarchive-c"],
+        "gui": ["panel"],
     },
     zip_safe=False,
 )


### PR DESCRIPTION
Fixes #768 and then some.

In addition to adding fusepy as an extra dependency and correcting the mention of the dependency in the docs (as discussed in #768), this PR also adds extra dependencies for installing libarchive-c and panel, and it also fixes a number of warnings generated when building the docs with Sphinx v4.0.2.

Unfortunately, building the docs still produces a number of warnings of the form "stub file not found \*. Check your autosummary_generate setting." which I was unable to resolve (regardless of whether `autosummary_generate` was set to `True` or `False`).  A possibly related issue is that, when a class inherits one or more methods, those methods will be listed in the class's method summary, but they will not be hyperlinked, and no documentation for the inherited methods will be included in the subclass; this can be fixed with the `:inherited-members:` flag of `.. autoclass::`, but that results in the documentation for inherited methods appearing under both the parent and child classes, so I leave it up to you to decide how best to handle this.