### PR TITLE
spec: put_file should use _parent()

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -802,7 +802,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
             callback.set_size(f1.seek(0, 2))
             f1.seek(0)
 
-            self.mkdirs(os.path.dirname(rpath), exist_ok=True)
+            self.mkdirs(self._parent(os.fspath(rpath)), exist_ok=True)
             with self.open(rpath, "wb", **kwargs) as f2:
                 data = True
                 while data:


### PR DESCRIPTION
`os.path.dirname()` is a OS specific handling of the parent logic, but in this case `rpath` is a remote-fs path so it should be handled using `_parent()` (which can be overriden by the downstream).