### PR TITLE
Fix Infinte loop with filecache and check_files=True #738

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -161,6 +161,7 @@ class CachingFileSystem(AbstractFileSystem):
                     else:
                         c["blocks"] = set(c["blocks"]).union(cache[k]["blocks"])
                     c["time"] = max(c["time"], cache[k]["time"])
+                    c["uid"] = cache[k]["uid"]
 
             # Files can be added to cache after it was written once
             for k, c in cache.items():

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -529,7 +529,7 @@ def test_filecache_with_checks():
     assert fs.cat(f1) == data  # does not change
     assert fs2.cat(f1) == data * 2  # changed, since origin changed
     with fs2.open(f1) as f:
-        assert f.read() == data * 2 # read also sees new data
+        assert f.read() == data * 2  # read also sees new data
     time.sleep(0.11)  # allow cache details to expire
     assert fs.cat(f1) == data * 2  # changed, since origin changed
 

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -528,6 +528,8 @@ def test_filecache_with_checks():
 
     assert fs.cat(f1) == data  # does not change
     assert fs2.cat(f1) == data * 2  # changed, since origin changed
+    with fs2.open(f1) as f:
+        assert f.read() == data * 2 # read also sees new data
     time.sleep(0.11)  # allow cache details to expire
     assert fs.cat(f1) == data * 2  # changed, since origin changed
 


### PR DESCRIPTION
Fixes https://github.com/intake/filesystem_spec/issues/738

Addition to test_filecache_with_checks catches the issue and is passed by the added line.

Regards,
Edward
