### PR TITLE
hdfs: ensure the protocol is stripped for each path

### DIFF
--- a/fsspec/implementations/tests/test_hdfs.py
+++ b/fsspec/implementations/tests/test_hdfs.py
@@ -75,7 +75,7 @@ def test_read(hdfs):
         assert f.read(100) + f.read() == data
 
 
-def test_copying(hdfs):
+def test_copy(hdfs):
     fs = fsspec.filesystem("hdfs")
 
     fs.mkdir(basedir + "/test_dir")
@@ -92,7 +92,7 @@ def test_copying(hdfs):
     ]
 
 
-def test_getting(hdfs, tmpdir):
+def test_put_get(hdfs, tmpdir):
     fs = fsspec.filesystem("hdfs")
 
     src_dir = Path(tmpdir / "source")
@@ -123,3 +123,17 @@ def test_getting(hdfs, tmpdir):
     assert {
         (dst_dir / file).read_text() for file in files if (dst_dir / file).is_file()
     } == {"file_1", "file_2", "file_3", "file_4"}
+
+
+def test_put_file_get_file(hdfs, tmpdir):
+    fs = fsspec.filesystem("hdfs")
+
+    src_file = Path(tmpdir / "src_file")
+    dst_file = Path(tmpdir / "dst_file")
+
+    src_file.write_bytes(b"heyhey")
+
+    fs.put_file(src_file, basedir + "/src_file")
+    fs.get_file(basedir + "/src_file", dst_file)
+
+    assert dst_file.read_bytes() == b"heyhey"

--- a/fsspec/implementations/tests/test_hdfs.py
+++ b/fsspec/implementations/tests/test_hdfs.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 import fsspec
@@ -30,9 +32,19 @@ def hdfs(request):
 
 
 def test_ls(hdfs):
-    h = fsspec.filesystem("hdfs")
-    out = [f["name"] for f in h.ls(basedir)]
-    assert out == hdfs.ls(basedir)
+    fs = fsspec.filesystem("hdfs")
+    fs.touch(basedir + "/file_2")
+    fs.mkdir(basedir + "/dir_1")
+    fs.touch(basedir + "/dir_1/file_1")
+    fs.mkdir(basedir + "/dir_2")
+
+    out = {(f["name"], f["kind"]) for f in fs.ls(basedir)}
+    assert out == {
+        (basedir + "/file", "file"),
+        (basedir + "/file_2", "file"),
+        (basedir + "/dir_1", "directory"),
+        (basedir + "/dir_2", "directory"),
+    }
 
 
 def test_walk(hdfs):
@@ -61,3 +73,53 @@ def test_read(hdfs):
         assert f.read() == data
     with h.open(out, "rb") as f:
         assert f.read(100) + f.read() == data
+
+
+def test_copying(hdfs):
+    fs = fsspec.filesystem("hdfs")
+
+    fs.mkdir(basedir + "/test_dir")
+    fs.touch(basedir + "/test_dir/a")
+    fs.touch(basedir + "/test_dir/b")
+    fs.mkdir(basedir + "/test_dir/c")
+    fs.touch(basedir + "/test_dir/c/d")
+
+    fs.copy(basedir + "/test_dir", basedir + "/copy_dir", recursive=True)
+    assert fs.find(basedir + "/copy_dir", detail=False) == [
+        basedir + "/copy_dir" + "/a",
+        basedir + "/copy_dir" + "/b",
+        basedir + "/copy_dir" + "/c/d",
+    ]
+
+
+def test_getting(hdfs, tmpdir):
+    fs = fsspec.filesystem("hdfs")
+
+    src_dir = Path(tmpdir / "source")
+    dst_dir = Path(tmpdir / "destination")
+
+    src_dir.mkdir()
+    (src_dir / "file_1.txt").write_text("file_1")
+    (src_dir / "file_2.txt").write_text("file_2")
+    (src_dir / "dir_1").mkdir()
+    (src_dir / "dir_1" / "file_3.txt").write_text("file_3")
+    (src_dir / "dir_1" / "file_4.txt").write_text("file_4")
+    (src_dir / "dir_2").mkdir()
+
+    fs.put(str(src_dir), basedir + "/src", recursive=True)
+    fs.get(basedir + "/src", str(dst_dir), recursive=True)
+
+    files = [file.relative_to(dst_dir) for file in dst_dir.glob("**/*")]
+
+    assert set(map(str, files)) == {
+        "file_1.txt",
+        "file_2.txt",
+        "dir_1/file_3.txt",
+        "dir_1/file_4.txt",
+        "dir_1",
+        "dir_2",
+    }
+
+    assert {
+        (dst_dir / file).read_text() for file in files if (dst_dir / file).is_file()
+    } == {"file_1", "file_2", "file_3", "file_4"}


### PR DESCRIPTION
There a couple minor changes, as well as the primary one which is under `_adjust_entry`. In the previous revision (08.01) we called `_strip_protocol()` for each item returned from the `ls()`. When I was refactoring this part of the codebase, I unified this logic with `info()` but then we only started to do it when the `'name'` was missing. The primary fix that should resolve #777 is that, now we do it unconditonally on the `_adjust_entry` if the given entry has any `name` field at all. 