### PR TITLE
http: only close connector if it is available

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -123,9 +123,10 @@ class HTTPFileSystem(AsyncFileSystem):
                 return
             except (TimeoutError, FSTimeoutError):
                 pass
-        if session._connector is not None:
+        connector = getattr(session, "_connector", None)
+        if connector is not None:
             # close after loop is dead
-            session._connector._close()
+            connector._close()
 
     async def set_session(self):
         if self._session is None:

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -488,13 +488,6 @@ async def get_proxy():
     return ProxyClient()
 
 
-@pytest.mark.parametrize("get_client", [get_aiohttp, get_proxy])
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
-def test_close(get_client):
-    fs = fsspec.filesystem("http", skip_instance_cache=True)
-    fs.close_session(None, asyncio.run(get_client()))
-
-
 @pytest.mark.xfail(
     condition=sys.flags.optimize > 1, reason="no docstrings when optimised"
 )
@@ -568,3 +561,10 @@ def test_processes(server, method):
     out = q.get()
     assert out == fs.cat(fn)
     p.join()
+
+
+@pytest.mark.parametrize("get_client", [get_aiohttp, get_proxy])
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
+def test_close(get_client):
+    fs = fsspec.filesystem("http", skip_instance_cache=True)
+    fs.close_session(None, asyncio.run(get_client()))

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -475,6 +475,26 @@ def test_put_file(server, tmp_path, method, reset_files):
     assert fs.cat(server + "/hey_3") == b"yyy"
 
 
+async def get_aiohttp():
+    from aiohttp import ClientSession
+
+    return ClientSession()
+
+
+async def get_proxy():
+    class ProxyClient:
+        pass
+
+    return ProxyClient()
+
+
+@pytest.mark.parametrize("get_client", [get_aiohttp, get_proxy])
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
+def test_close(get_client):
+    fs = fsspec.filesystem("http", skip_instance_cache=True)
+    fs.close_session(None, asyncio.run(get_client()))
+
+
 @pytest.mark.xfail(
     condition=sys.flags.optimize > 1, reason="no docstrings when optimised"
 )


### PR DESCRIPTION
Stuff like `asyncio-retry` offer their own clients which proxy the original `ClientSession`, and they do not bind stuff like `_connector` directly. Since this is a private-attribute, it might be nicer if we access it optionally and only try to close if we can find it.