### PR TITLE
Fix for #788

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+2021.10.1 (in development)
+--------------------------
+
+Fixes
+
+- Removed inaccurate `ZipFileSystem.cat()` override so that the base
+  class' version is used (#788)
+
+
 2021.10.0
 ---------
 

--- a/fsspec/implementations/tests/test_zip.py
+++ b/fsspec/implementations/tests/test_zip.py
@@ -1,3 +1,5 @@
+import collections.abc
+
 import fsspec
 from fsspec.implementations.tests.test_archive import archive_data, tempzip
 
@@ -13,3 +15,24 @@ def test_info():
             # Probe some specific fields of Zip archives.
             assert "CRC" in lhs
             assert "compress_size" in lhs
+
+
+def test_fsspec_get_mapper():
+    """Added for #788"""
+
+    with tempzip(archive_data) as z:
+        mapping = fsspec.get_mapper(f"zip::{z}")
+
+        assert isinstance(mapping, collections.abc.Mapping)
+        keys = sorted(list(mapping.keys()))
+        assert keys == ['a', 'b', 'deeply/nested/path']
+
+        # mapping.getitems() will call FSMap.fs.cat()
+        # which was not accurately implemented for zip.
+        assert isinstance(mapping, fsspec.mapping.FSMap)
+        items = dict(mapping.getitems(keys))
+        assert items == {
+            'a': b'',
+            'b': b'hello',
+            'deeply/nested/path': b'stuff'
+        }

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -81,9 +81,6 @@ class ZipFileSystem(AbstractArchiveFileSystem):
                 )
                 self.dir_cache[f["name"]] = f
 
-    def cat(self, path, callback=None, **kwargs):
-        return self.zip.read(path)
-
     def _open(
         self,
         path,


### PR DESCRIPTION
Removed inaccurate `ZipFileSystem.cat()` override so that the base class' version is used (#788)