### PR TITLE
DOC: minor typos fixed while glancing through the code

### DIFF
--- a/fsspec/_version.py
+++ b/fsspec/_version.py
@@ -330,7 +330,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
         # TAG-NUM-gHEX
         mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
-            # unparseable. Maybe git-describe is misbehaving?
+            # unparsable. Maybe git-describe is misbehaving?
             pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 

--- a/fsspec/callbacks.py
+++ b/fsspec/callbacks.py
@@ -69,13 +69,13 @@ class Callback:
         """
         Execute hook(s) with current state
 
-        Each funcion is passed the internal size and current value
+        Each function is passed the internal size and current value
 
         Parameters
         ----------
         hook_name: str or None
             If given, execute on this hook
-        kwargs: passed on to (all) hoook(s)
+        kwargs: passed on to (all) hook(s)
         """
         if not self.hooks:
             return

--- a/fsspec/implementations/dbfs.py
+++ b/fsspec/implementations/dbfs.py
@@ -102,7 +102,7 @@ class DatabricksFileSystem(AbstractFileSystem):
         """
         if not exist_ok:
             try:
-                # If the folowing succeeds, the path is already present
+                # If the following succeeds, the path is already present
                 self._send_to_api(
                     method="get", endpoint="get-status", json={"path": path}
                 )

--- a/fsspec/implementations/github.py
+++ b/fsspec/implementations/github.py
@@ -70,7 +70,7 @@ class GithubFileSystem(AbstractFileSystem):
         Parameters
         ----------
         org_or_user: str
-            Nmae of the github org or user to query
+            Name of the github org or user to query
         is_org: bool (default True)
             Whether the name is an organisation (True) or user (False)
 

--- a/fsspec/implementations/hdfs.py
+++ b/fsspec/implementations/hdfs.py
@@ -156,7 +156,7 @@ class PyArrowHDFS(AbstractFileSystem):
 
         with self.open(lpath) as lstream:
             tmp_fname = "/".join([self._parent(rpath), f".tmp.{secrets.token_hex(16)}"])
-            # Perform an atomic copy (stream to a temporory file and
+            # Perform an atomic copy (stream to a temporary file and
             # move it to the actual destination).
             try:
                 with self.open(tmp_fname, "wb") as rstream:

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -445,7 +445,7 @@ def test_filecache_multicache():
     assert fs.cat(f1) == data
 
     assert len(os.listdir(cache1)) == 2  # cache and hashed afile
-    assert len(os.listdir(cache2)) == 0  # hasn't been intialized yet
+    assert len(os.listdir(cache2)) == 0  # hasn't been initialized yet
 
     # populates last cache if file not found in first cache
     fs = fsspec.filesystem(

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -5,12 +5,12 @@ import pytest
 
 def test_1(m):
     m.touch("/somefile")  # NB: is found with or without initial /
-    m.touch("afiles/and/anothers")
+    m.touch("afiles/and/another")
     files = m.find("")
-    assert files == ["/afiles/and/anothers", "/somefile"]
+    assert files == ["/afiles/and/another", "/somefile"]
 
     files = sorted(m.get_mapper("/"))
-    assert files == ["afiles/and/anothers", "somefile"]
+    assert files == ["afiles/and/another", "somefile"]
 
 
 def test_strip(m):

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -342,7 +342,7 @@ class WebHDFS(AbstractFileSystem):
     def cp_file(self, lpath, rpath, **kwargs):
         with self.open(lpath) as lstream:
             tmp_fname = "/".join([self._parent(rpath), f".tmp.{secrets.token_hex(16)}"])
-            # Perform an atomic copy (stream to a temporory file and
+            # Perform an atomic copy (stream to a temporary file and
             # move it to the actual destination).
             try:
                 with self.open(tmp_fname, "wb") as rstream:

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -213,7 +213,7 @@ def get_mapper(
         Whether to make the directory corresponding to the root before
         instantiating
     missing_exceptions: None or tuple
-        If given, these excpetion types will be regarded as missing keys and
+        If given, these exception types will be regarded as missing keys and
         return KeyError when trying to read data. By default, you get
         (FileNotFoundError, IsADirectoryError, NotADirectoryError)
     alternate_root: None or str

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -259,7 +259,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
         # Not necessary to implement invalidation mechanism, may have no cache.
         # But if have, you should call this method of parent class from your
         # subclass to ensure expiring caches after transacations correctly.
-        # See the implementaion of FTPFileSystem in ftp.py
+        # See the implementation of FTPFileSystem in ftp.py
         if self._intrans:
             self._invalidated_caches_in_transaction.append(path)
 
@@ -1145,7 +1145,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
     def get_mapper(self, root, check=False, create=False):
         """Create key/value store based on this file-system
 
-        Makes a MutibleMapping interface to the FS at the given root path.
+        Makes a MutableMapping interface to the FS at the given root path.
         See ``fsspec.mapping.FSMap`` for further details.
         """
         from .mapping import FSMap
@@ -1242,7 +1242,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
 
         Raises
         ------
-        NotImplementedError : if method is not implemented for a fileystem
+        NotImplementedError : if method is not implemented for a filesystem
         """
         raise NotImplementedError("Sign is not implemented for this filesystem")
 

--- a/fsspec/tests/test_file.py
+++ b/fsspec/tests/test_file.py
@@ -166,7 +166,7 @@ def test_read_block(ftp_writable):
 def test_with_gzip(ftp_writable):
     import gzip
 
-    data = b"some compressable stuff"
+    data = b"some compressible stuff"
     host, port, user, pw = ftp_writable
     fs = FTPFileSystem(host=host, port=port, username=user, password=pw)
     fn = "/myfile"

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -389,7 +389,7 @@ def get_protocol(url):
 
 
 def can_be_local(path):
-    """Can the given URL be used wih open_local?"""
+    """Can the given URL be used with open_local?"""
     from fsspec import get_filesystem_class
 
     try:
@@ -488,7 +488,7 @@ def nullcontext(obj):
 def merge_offset_ranges(paths, starts, ends, max_gap=0, max_block=None, sort=True):
     """Merge adjacent byte-offset ranges when the inter-range
     gap is <= `max_gap`, and when the merged byte range does not
-    exceed `max_block` (if specified). By defaut, this function
+    exceed `max_block` (if specified). By default, this function
     will re-order the input paths and byte ranges to ensure sorted
     order. If the user can guarantee that the inputs are already
     sorted, passing `sort=False` will skip the re-ordering.


### PR DESCRIPTION
Most were found by codespell but some were "rejected" since were relating
to code naming conventions etc.