### PR TITLE
hdfs: switch to pyarrow.fs

### DIFF
--- a/fsspec/implementations/hdfs.py
+++ b/fsspec/implementations/hdfs.py
@@ -3,7 +3,7 @@ import shutil
 import weakref
 from contextlib import suppress
 
-from pyarrow.hdfs import HadoopFileSystem
+from pyarrow.fs import HadoopFileSystem
 
 from fsspec.implementations.arrow import wrap_exceptions
 from fsspec.spec import AbstractFileSystem

--- a/fsspec/implementations/tests/test_hdfs.py
+++ b/fsspec/implementations/tests/test_hdfs.py
@@ -13,7 +13,7 @@ data = b"\n".join([b"some test data"] * 1000)
 @pytest.fixture
 def hdfs(request):
     try:
-        hdfs = pyarrow.hdfs.HadoopFileSystem()
+        hdfs = pyarrow.fs.HadoopFileSystem()
     except IOError:
         pytest.skip("No HDFS configured")
 


### PR DESCRIPTION
Should fix `FutureWarning: pyarrow.hdfs.HadoopFileSystem is deprecated as of 2.0.0, please use pyarrow.fs.HadoopFileSystem instead.`.