### PR TITLE
Add metadata option to open_parquet_file

### DIFF
--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -426,7 +426,7 @@ class AllBytes(BaseCache):
 class KnownPartsOfAFile(BaseCache):
     name = "parts"
 
-    def __init__(self, blocksize, fetcher, size, data={}, strict=False, **_):
+    def __init__(self, blocksize, fetcher, size, data={}, strict=True, **_):
         super(KnownPartsOfAFile, self).__init__(blocksize, fetcher, size)
         self.strict = strict
 

--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -442,6 +442,15 @@ class KnownPartsOfAFile(BaseCache):
                 else:
                     offsets.append((start, stop))
                     blocks.append(data.pop((start, stop)))
+
+            if self.size:
+                # If our last range goes to the end of the
+                # file, extend the range in case the read
+                # goes beyond the end of the file
+                last_key = offsets[-1]
+                if last_key[1] >= self.size:
+                    offsets[-1] = (last_key[0], max(last_key[1], self.size * 2))
+
             self.data = dict(zip(offsets, blocks))
         else:
             self.data = data

--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -424,6 +424,28 @@ class AllBytes(BaseCache):
 
 
 class KnownPartsOfAFile(BaseCache):
+    """
+    Cache holding known file parts.
+
+    Parameters
+    ----------
+    blocksize: int
+        How far to read ahead in numbers of bytes
+    fetcher: func
+        Function of the form f(start, end) which gets bytes from remote as
+        specified
+    size: int
+        How big this file is
+    data: dict
+        A dictionary mapping explicit `(start, stop)` file-offset tuples
+        with known bytes.
+    strict: bool, default True
+        Whether to fetch reads that go beyond a known byte-range boundary.
+        If `False`, any read that ends outside a known part will be zero
+        padded. Note that zero padding will not be used for reads that
+        begin outside a known byte-range.
+    """
+
     name = "parts"
 
     def __init__(self, blocksize, fetcher, size, data={}, strict=True, **_):
@@ -482,6 +504,7 @@ class KnownPartsOfAFile(BaseCache):
             f"Read is outside the known file parts: {(start, stop)}. "
             f"IO/caching performance may be poor!"
         )
+        logger.debug(f"KnownPartsOfAFile cache fetching {start}-{stop}")
         return out + super()._fetch(start, stop)
 
 

--- a/fsspec/parquet.py
+++ b/fsspec/parquet.py
@@ -21,6 +21,7 @@ def open_parquet_file(
     columns=None,
     row_groups=None,
     storage_options=None,
+    strict=False,
     engine="auto",
     max_gap=64_000,
     max_block=256_000_000,
@@ -68,6 +69,12 @@ def open_parquet_file(
     storage_options : dict, optional
         Used to generate an `AbstractFileSystem` object if `fs` was
         not specified.
+    strict : bool, optional
+        Whether the resulting `KnownPartsOfAFile` cache should
+        fetch reads that go beyond a known byte-range boundary.
+        If `False` (the default), any read that ends outside a
+        known part will be zero padded. Note that using
+        `strict=True` may be useful for debugging.
     max_gap : int, optional
         Neighboring byte ranges will only be merged when their
         inter-range gap is <= `max_gap`. Default is 64KB.
@@ -124,7 +131,13 @@ def open_parquet_file(
         fn,
         mode=mode,
         cache_type="parts",
-        cache_options={**options, **{"data": data[fn]}},
+        cache_options={
+            **options,
+            **{
+                "data": data[fn],
+                "strict": strict,
+            },
+        },
         **kwargs,
     )
 

--- a/fsspec/parquet.py
+++ b/fsspec/parquet.py
@@ -16,6 +16,7 @@ from .utils import merge_offset_ranges
 
 def open_parquet_file(
     path,
+    mode="rb",
     fs=None,
     metadata=None,
     columns=None,
@@ -44,6 +45,8 @@ def open_parquet_file(
     ----------
     path: str
         Target file path.
+    mode: str, optional
+        Mode option to be passed through to `fs.open`. Default is "rb".
     metadata: Any, optional
         Parquet metadata object. Object type must be supported
         by the backend parquet engine. For now, only the "fastparquet"
@@ -118,7 +121,6 @@ def open_parquet_file(
 
     # If data is empty, just use default
     # `open` command with `path` input
-    mode = kwargs.pop("mode", "rb")
     if len(data) != 1:
         return fs.open(path, mode=mode)
 

--- a/fsspec/parquet.py
+++ b/fsspec/parquet.py
@@ -98,9 +98,10 @@ def open_parquet_file(
     if fs is None:
         fs = url_to_fs(path, storage_options=(storage_options or {}))[0]
 
-    # For now, `columns == []` not supported
+    # For now, `columns == []` not supported. Just use
+    # default `open` command with `path` input
     if columns is not None and len(columns) == 0:
-        raise ValueError("Empty columns input not supported")
+        return fs.open(path, mode=mode)
 
     # Set the engine
     engine = _set_engine(engine)

--- a/fsspec/parquet.py
+++ b/fsspec/parquet.py
@@ -330,10 +330,9 @@ def _get_parquet_byte_ranges_from_metadata(
     return result
 
 
-def _transfer_ranges(fs, blocks, *ranges):
+def _transfer_ranges(fs, blocks, paths, starts, ends):
     # Use cat_ranges to gather the data byte_ranges
-    if len(ranges) != 3:
-        raise ValueError("Incorrect arg count passed to _transfer_ranges")
+    ranges = (paths, starts, ends)
     for path, start, stop, data in zip(*ranges, fs.cat_ranges(*ranges)):
         blocks[path][(start, stop)] = data
 

--- a/fsspec/tests/test_parquet.py
+++ b/fsspec/tests/test_parquet.py
@@ -99,3 +99,31 @@ def test_open_parquet_file(
 
     # Check that `result` matches `expect`
     pd.testing.assert_frame_equal(expect, result)
+
+    # Try passing metadata
+    if engine == "fastparquet":
+        # Should work fine for "fastparquet"
+        pf = fastparquet.ParquetFile(path)
+        with open_parquet_file(
+            path,
+            metadata=pf,
+            columns=columns,
+            engine=engine,
+            max_gap=max_gap,
+            max_block=max_block,
+            footer_sample_size=footer_sample_size,
+        ) as f:
+            result = pd.read_parquet(f, columns=columns)
+        pd.testing.assert_frame_equal(expect, result)
+    elif engine == "pyarrow":
+        # Should raise ValueError for "pyarrow"
+        with pytest.raises(ValueError):
+            open_parquet_file(
+                path,
+                metadata=["Not-None"],
+                columns=columns,
+                engine=engine,
+                max_gap=max_gap,
+                max_block=max_block,
+                footer_sample_size=footer_sample_size,
+            )

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -504,6 +504,10 @@ def merge_offset_ranges(paths, starts, ends, max_gap=0, max_block=None, sort=Tru
     if len(starts) != len(paths) or len(ends) != len(paths):
         raise ValueError
 
+    # Early Return
+    if len(starts) <= 1:
+        return paths, starts, ends
+
     # Sort by paths and then ranges if `sort=True`
     if sort:
         paths, starts, ends = [list(v) for v in zip(*sorted(zip(paths, starts, ends)))]


### PR DESCRIPTION
This is a follow-up to #806 (where a new `fsspec.parquet` module was added). The most important changes in this PR are the following:

1. Adds a new `metadata` argument to `open_parquet_file`
2. Expands the `row_group` argument of `open_parquet_file` so that the user may optionally pass in a list of distinct engine-specific row-group metadata (rather than a list of row-group indices).
3. Adds a `strict` option to `KnownPartsOfAFile` (defaulting to `True`). When `strict=False`, reads that extend beyond the boundary of a known part will be zero-buffered. When `strict=True`, the missing range will be explicitly fetched from the remote source. Note that the `strict` logic only applies to reads that begin within a known part. It seems that Fastparquet will often seek to an offset within a known part, but then read slightly beyond the end of the buffer/file. I experimented with various ways to deal with this, but using `strict=False` (within `open_parquet_file`) seems to be the simplest way to avoid constant errors/warnings and unnecessary data transfer. Note that the user can always set `strict=True` for debugging purposes.

The primary purpose of this PR is to make it possible to utilize `open_parquet_file` within Dask for better remote-file perfomance in `dask.dataframe.read_parquet`.  Without these changes, only the "pyarrow" engine can benefit from the new optimization.

Note that these chnges do not (yet) add support for pyarrow-based metadata input. I will target that feature in a separate PR.