### PR TITLE
fix 'find' with protocol striped

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -446,7 +446,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
         for _, dirs, files in self.walk(path, maxdepth, detail=True, **kwargs):
             if withdirs:
                 files.update(dirs)
-            out.update({info["name"]: info for name, info in files.items()})
+            out.update({self._strip_protocol(info["name"]): info for name, info in files.items()})
         if not out and self.isfile(path):
             # walk works on directories, but find should also return [path]
             # when path happens to be a file


### PR DESCRIPTION
**Problem**: This exception was found by reading parquet from HDFS dir with `dask.dataframe` and nothing returned in my case. After some digging, I think it might be raised by the function `glob` in `spec.py`. 

**Caused by**: In `spec.py`, line 537 parses all files in the given input dir, the files returned by `find` are presented with protocol included. However, the `re.match` operation in line 564, the match pattern starts with path without protocol, finally, `glob` returns None.

**Solution**: As the PR

**Note**: I've tested in my case, after modifying the function `find`, I can read my HDFS correctly. But I'm not sure by now whether this modification would affect other cases.

